### PR TITLE
ENYO-4136: Removed indexToFocus

### DIFF
--- a/pattern-virtualgridlist-api/src/views/MainView.js
+++ b/pattern-virtualgridlist-api/src/views/MainView.js
@@ -19,11 +19,11 @@ class MainView extends React.Component {
 	componentDidMount () {
 		// Below is an example of using scrollTo method for setting an "initial" position of VirtualList.
 		// It is a substitute for focusOnIndex, setInitialFocusIndex, and scrollToItem of enyo.
-		this.scrollTo({index: 60, animate: false, indexToFocus: 60});
+		this.scrollTo({index: 60, animate: false, focus: true});
 	}
 
 	componentDidUpdate () {
-		this.scrollTo({index: 0, animate: false, indexToFocus: 0});
+		this.scrollTo({index: 0, animate: false, focus: true});
 	}
 
 	onChange = (ev) => {


### PR DESCRIPTION
**Issue Resolved / Feature Added**
To remove the warning from using `indexToFocus`, replaced the option to `focus`.

**Link**
ENYO-4136

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)