### PR TITLE
ENYO-4245: Fix header buttons display

### DIFF
--- a/pattern-virtualgridlist-api/src/App/App.js
+++ b/pattern-virtualgridlist-api/src/App/App.js
@@ -21,4 +21,4 @@ const App = kind({
 	)
 });
 
-export default MoonstoneDecorator(App);
+export default MoonstoneDecorator({noAutoFocus: true}, App);

--- a/pattern-virtualgridlist-api/src/components/GalleryPanelHeader/GalleryPanelHeader.js
+++ b/pattern-virtualgridlist-api/src/components/GalleryPanelHeader/GalleryPanelHeader.js
@@ -57,22 +57,49 @@ const GalleryPanelHeader = kind({
 		}
 	},
 
-	render: ({addMockItem, deleteItem, selectAll, showOverlay, showSelectionOverlayHandler, ...rest}) => {
+	computed: {
+		selectionPreviousButton: ({showOverlay, showSelectionOverlayHandler}) => {
+			const
+				tooltipText = showOverlay ? "Previous" : "Selection",
+				icon = showOverlay ? "rollbackward" : "check";
+			return (
+				<IconButton tooltipText={tooltipText} small onClick={showSelectionOverlayHandler}>{icon}</IconButton>
+			);
+		},
+		addButton: ({addMockItem, showOverlay}) => {
+			if (!showOverlay) {
+				return (<IconButton tooltipText="Add Item" small onClick={addMockItem}>plus</IconButton>);
+			}
+		},
+		deleteButton: ({deleteItem, showOverlay}) => {
+			if (showOverlay) {
+				return (<Button small onClick={deleteItem}>Delete</Button>);
+			}
+		},
+		selectAllButton: ({selectAll, showOverlay}) => {
+			if (showOverlay) {
+				return (<Button small onClick={selectAll}>Select All</Button>);
+			}
+		}
+	},
+
+	render: ({addButton, deleteButton, selectAllButton, selectionPreviousButton, ...rest}) => {
 		delete rest.album;
 		delete rest.albumSize;
 		delete rest.addItem;
+		delete rest.addMockItem;
 		delete rest.deleteItem;
 		delete rest.selectAll;
 		delete rest.selectionEnable;
 		delete rest.showOverlay;
+		delete rest.showSelectionOverlayHandler;
 
 		return (
 			<Header {...rest}>
-				{!showOverlay && <IconButton tooltipText="Add Item" small onClick={addMockItem}>plus</IconButton>}
-				{showOverlay && <Button small onClick={deleteItem}>Delete</Button>}
-				{showOverlay && <Button small onClick={selectAll}>Select All</Button>}
-				{!showOverlay && <IconButton tooltipPosition="above" tooltipText="Selection" small onClick={showSelectionOverlayHandler}>check</IconButton>}
-				{showOverlay && <IconButton tooltipPosition="above" tooltipText="Go To Previous" small onClick={showSelectionOverlayHandler}>rollbackward</IconButton>}
+				{addButton}
+				{deleteButton}
+				{selectAllButton}
+				{selectionPreviousButton}
 			</Header>
 		);
 	}


### PR DESCRIPTION
Fix how to display gallery header buttons.

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The spotlight is hidden because the previously focused button is hidden, so we create one IconButton not separating two buttons.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The props related aria is set to slider using extractAriaProps util.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
If the tooltipText length is changed dynamically and the tooltip is showing, tooltip position is not adjusted, So I changed tooltipText properly because there isn't how to adjust tooltip position in App side. 

### Links
[//]: # (Related issues, references)
ENYO-4245

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>