### PR TITLE
ENYO-4594: Set valid panel index for pattern-video-player

### DIFF
--- a/pattern-video-player/src/App/App.js
+++ b/pattern-video-player/src/App/App.js
@@ -51,7 +51,7 @@ class App extends React.Component {
 
 	handleNextPanelClick = () => this.setState({panelIndex: this.state.panelIndex + 1})
 
-	handleSelectBreadcrumb = ({panelIndex}) => this.setState({panelIndex})
+	handleSelectBreadcrumb = ({index}) => this.setState({panelIndex: index})
 
 	handleShowPanelsClick = () => this.setState({panelsVisible: true})
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
The pattern-video-player sample was setting an invalid `panelIndex` value when selecting a breadcrumb.

### Resolution
Retrieve the `index` (rather than the `panelIndex`) prop value of the `onSelectBreadcrumb` event object.

Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>