### PR TITLE
ENYO-4523: VideoPlayer Sample Update with SpotlightDisabled

### DIFF
--- a/pattern-video-player/src/App/App.js
+++ b/pattern-video-player/src/App/App.js
@@ -82,6 +82,7 @@ class App extends React.Component {
 						<IconButton
 							backgroundOpacity="translucent"
 							onClick={this.handleShowPanelsClick}
+							spotlightDisabled={this.state.panelsVisible}
 						>
 							list
 						</IconButton>


### PR DESCRIPTION
### Issue Resolved / Feature Added
Spotlight does not jump to foreground when opening panels in VideoPlayer sample.

### Resolution
Disable Spotlight when panels show.

### Link
ENYO-4523

Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com

