### PR TITLE
PLAT-50772: Rename the `component` prop as `itemRenderer`

### DIFF
--- a/pattern-virtualgridlist-api/src/components/ImageList/ImageList.js
+++ b/pattern-virtualgridlist-api/src/components/ImageList/ImageList.js
@@ -25,9 +25,9 @@ class ImageList extends React.Component {
 		return (
 			<VirtualGridList
 				{...rest}
-				component={this.renderItem}
 				data={imageitems}
 				dataSize={imageitems.length}
+				itemRenderer={this.renderItem}
 				itemSize={{minHeight: ri.scale(270), minWidth: ri.scale(180)}}
 				spacing={ri.scale(21)}
 			/>

--- a/pattern-virtuallist-preserving-focus/src/views/PatternList.js
+++ b/pattern-virtuallist-preserving-focus/src/views/PatternList.js
@@ -49,10 +49,10 @@ class PatternListBase extends Component {
 			<VirtualList
 				cbScrollTo={this.getScrollTo}
 				className={css.list}
-				component={this.renderItem}
 				containerId={id} // Set a unique ID to preserve last focus
 				data={items}
 				dataSize={items.length}
+				itemRenderer={this.renderItem}
 				itemSize={ri.scale(72)}
 				onScrollStop={onScrollStop} // Set this to save last scroll position when unmount
 			/>


### PR DESCRIPTION
Rename the `component` prop as `itemRenderer`

**This commit must be merged after the (https://github.com/enactjs/enact/pull/1500) is merged.**

Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)