### PR TITLE
ENYO-5161: Fix reference to containerId

### DIFF
--- a/pattern-virtuallist-preserving-focus/src/views/PatternList.js
+++ b/pattern-virtuallist-preserving-focus/src/views/PatternList.js
@@ -50,7 +50,7 @@ class PatternListBase extends Component {
 			<VirtualList
 				cbScrollTo={this.getScrollTo}
 				className={css.list}
-				containerId={id} // Set a unique ID to preserve last focus
+				spotlightId={id} // Set a unique ID to preserve last focus
 				dataSize={items.length}
 				itemRenderer={this.renderItem}
 				itemSize={ri.scale(72)}


### PR DESCRIPTION
`containerId` has been replaced by `spotlightId`

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)