### PR TITLE
ENYO-5327: Fix to show missing right icon

### DIFF
--- a/pattern-video-player/src/App/App.js
+++ b/pattern-video-player/src/App/App.js
@@ -3,7 +3,7 @@ import IconButton from '@enact/moonstone/IconButton';
 import MoonstoneDecorator from '@enact/moonstone/MoonstoneDecorator';
 import PropTypes from 'prop-types';
 import React from 'react';
-import VideoPlayer from '@enact/moonstone/VideoPlayer';
+import VideoPlayer, {MediaControls} from '@enact/moonstone/VideoPlayer';
 
 import ItemPanel from '../views/ItemPanel';
 import MainPanel from '../views/MainPanel';
@@ -44,7 +44,7 @@ class App extends React.Component {
 
 		this.state = {
 			panelIndex: this.props.panelIndex,
-			panelsVisible: true,
+			panelsVisible: false,
 			videoIndex: this.props.videoIndex
 		};
 	}
@@ -78,15 +78,17 @@ class App extends React.Component {
 					<infoComponents>
 						{desc}
 					</infoComponents>
-					<rightComponents>
-						<IconButton
-							backgroundOpacity="translucent"
-							onClick={this.handleShowPanelsClick}
-							spotlightDisabled={this.state.panelsVisible}
-						>
-							list
-						</IconButton>
-					</rightComponents>
+					<MediaControls>
+						<rightComponents>
+							<IconButton
+								backgroundOpacity="translucent"
+								onClick={this.handleShowPanelsClick}
+								spotlightDisabled={this.state.panelsVisible}
+							>
+								list
+							</IconButton>
+						</rightComponents>
+					</MediaControls>
 				</VideoPlayer>
 				{this.state.panelsVisible ?
 					<AlwaysViewingPanels


### PR DESCRIPTION
Update `rightComponents` declaration introduced by https://github.com/enactjs/enact/pull/1574.

Also changed the default panel visibility value to `false` as the `VideoPlayer.MediaControls` appears at initial render. Suggesting not to render panel so that we can avoid two components clashing which result in awkward spotlight behavior.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>