### PR TITLE
ENYO-5601: Change Back button to disable spotlight

### DIFF
--- a/enact-all-samples/src/components/ButtonToSamples/ButtonToSamples.js
+++ b/enact-all-samples/src/components/ButtonToSamples/ButtonToSamples.js
@@ -9,6 +9,7 @@ const ButtonToSamples = () => (
 		<Link to="/" className={css.backLink}>
 			<Button
 				className={css.backButton}
+				spotlightDisabled
 				style={{zIndex: 1}}
 			>
 				Back To Samples


### PR DESCRIPTION
The "Back to all samples" button interferes with spotlight because it's out of the viewport. Since it only activates on hover anyway, we can disable spotlight on it and still support clicks. Also, because it's using react router's `Link`, it doesn't support navigation via 5-way anyway.