### PR TITLE
ENYO-5838: Fix cancel handling in pattern-dynamic-panel sample

### DIFF
--- a/pattern-activity-panels/package.json
+++ b/pattern-activity-panels/package.json
@@ -30,13 +30,15 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "next",
-    "@enact/i18n": "next",
-    "@enact/moonstone": "next",
-    "@enact/spotlight": "next",
-    "@enact/ui": "next",
+    "@enact/cli": "^1.2.1",
+    "@enact/core": "^2.2.9",
+    "@enact/i18n": "^2.2.9",
+    "@enact/moonstone": "^2.2.9",
+    "@enact/spotlight": "^2.2.9",
+    "@enact/ui": "^2.2.9",
+    "@enact/webos": "^2.2.9",
     "prop-types": "^15.6.0",
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0"
+    "react": "^16.4.2",
+    "react-dom": "^16.4.2"
   }
 }

--- a/pattern-activity-panels/package.json
+++ b/pattern-activity-panels/package.json
@@ -30,15 +30,13 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/cli": "^1.2.1",
-    "@enact/core": "^2.2.9",
-    "@enact/i18n": "^2.2.9",
-    "@enact/moonstone": "^2.2.9",
-    "@enact/spotlight": "^2.2.9",
-    "@enact/ui": "^2.2.9",
-    "@enact/webos": "^2.2.9",
+    "@enact/core": "next",
+    "@enact/i18n": "next",
+    "@enact/moonstone": "next",
+    "@enact/spotlight": "next",
+    "@enact/ui": "next",
     "prop-types": "^15.6.0",
-    "react": "^16.4.2",
-    "react-dom": "^16.4.2"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   }
 }

--- a/pattern-dynamic-panel/src/components/FileBrowser/FileBrowser.js
+++ b/pattern-dynamic-panel/src/components/FileBrowser/FileBrowser.js
@@ -132,7 +132,7 @@ const popPath = (pathData) => {
 // the onCancel callback from the Cancelable config receives the Cancelable's props to both
 // determine if it should cancel and how to handle the cancel. here, we're calling the onNavigate
 // event callback.
-const handleCancel = ({path, onNavigate}) => {
+const handleCancel = (ev, {path, onNavigate}) => {
 	// pop the path
 	const newPath = popPath(path);
 	// and if there's an onNavigate callback
@@ -143,7 +143,7 @@ const handleCancel = ({path, onNavigate}) => {
 		});
 
 		// then return true to indicate it was handled
-		return true;
+		ev.stopPropagation();
 	}
 };
 


### PR DESCRIPTION
### Issue
The sample only expects the props to be passed to the cancel handler and errors when trying to access them as a result.

### Resolution
Update the sample to use the correct API for cancel handlers (event payload and props)