### PR TITLE
Feature/ENYO-5970: samples: pattern-virtualgridlist-api missing required prop

### DIFF
--- a/pattern-virtualgridlist-api/src/components/SideBar/SideBar.js
+++ b/pattern-virtualgridlist-api/src/components/SideBar/SideBar.js
@@ -2,7 +2,9 @@ import Divider from '@enact/moonstone/Divider';
 import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {adaptEvent, handle, forward} from '@enact/core/handle';
 import SelectableItem from '@enact/moonstone/SelectableItem';
+import Group from '@enact/ui/Group';
 
 import css from './SideBar.module.less';
 
@@ -20,34 +22,27 @@ const SideBar = kind({
 		className: 'sideBar'
 	},
 
-	computed: {
-		albumList: ({albums, onAlbumChange, selectedAlbum}) => {
-			return albums.map((album, index) => {
-				return (
-					<div key={index}>
-						<SelectableItem
-							onToggle={onAlbumChange(album)}
-							selected={selectedAlbum === album}
-							value={album}
-						>
-							{album}
-						</SelectableItem>
-						<Divider spacing="small" />
-					</div>
-				);
-			});
-		}
+	handlers: {
+		onAlbumChange: handle(
+			adaptEvent(ev => ({type: 'onChangeAlbum', album: ev.data}), forward('onAlbumChange')))
 	},
 
-	render: ({albumList, ...rest}) => {
+	render: ({albums, onAlbumChange, selectedAlbum, ...rest}) => {
 		delete rest.albums;
 		delete rest.onAlbumChange;
 		delete rest.selectedAlbum;
 
 		return (
-			<div {...rest}>
-				{albumList}
-			</div>
+			<Group 
+				childComponent={SelectableItem}
+				selectedProp="selected"
+				defaultSelected={0}
+				onSelect={onAlbumChange}
+				select="radio"
+				{...rest}
+			>
+				{albums}
+			</Group>
 		);
 	}
 });

--- a/pattern-virtualgridlist-api/src/components/SideBar/SideBar.js
+++ b/pattern-virtualgridlist-api/src/components/SideBar/SideBar.js
@@ -26,7 +26,7 @@ const SideBar = kind({
 				return (
 					<div key={index}>
 						<SelectableItem
-							onToggle={onAlbumChange}
+							onToggle={onAlbumChange(album)}
 							selected={selectedAlbum === album}
 							value={album}
 						>

--- a/pattern-virtualgridlist-api/src/components/SideBar/SideBar.js
+++ b/pattern-virtualgridlist-api/src/components/SideBar/SideBar.js
@@ -1,4 +1,3 @@
-import Divider from '@enact/moonstone/Divider';
 import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -13,7 +12,6 @@ const SideBar = kind({
 
 	propTypes: {
 		onAlbumChange: PropTypes.func.isRequired,
-		selectedAlbum: PropTypes.string.isRequired,
 		albums: PropTypes.array
 	},
 
@@ -27,16 +25,14 @@ const SideBar = kind({
 			adaptEvent(ev => ({type: 'onChangeAlbum', album: ev.data}), forward('onAlbumChange')))
 	},
 
-	render: ({albums, onAlbumChange, selectedAlbum, ...rest}) => {
+	render: ({albums, onAlbumChange, ...rest}) => {
 		delete rest.albums;
 		delete rest.onAlbumChange;
-		delete rest.selectedAlbum;
 
 		return (
-			<Group 
+			<Group
 				childComponent={SelectableItem}
 				selectedProp="selected"
-				defaultSelected={0}
 				onSelect={onAlbumChange}
 				select="radio"
 				{...rest}

--- a/pattern-virtualgridlist-api/src/views/MainView.js
+++ b/pattern-virtualgridlist-api/src/views/MainView.js
@@ -35,8 +35,6 @@ class MainView extends React.Component {
 	}
 
 	render = () => {
-		const {album} = this.props;
-
 		return (
 			<div className={css.mainView}>
 				<GalleryPanelHeader title="My Gallery" />
@@ -45,7 +43,7 @@ class MainView extends React.Component {
 						albums={albums}
 						className={css.sideBar}
 						onAlbumChange={this.onChange}
-						selectedAlbum={album}
+						defaultSelected={0}
 					/>
 					<ImageList
 						cbScrollTo={this.getScrollTo}

--- a/pattern-virtualgridlist-api/src/views/MainView.js
+++ b/pattern-virtualgridlist-api/src/views/MainView.js
@@ -26,8 +26,7 @@ class MainView extends React.Component {
 		this.scrollTo({index: 0, animate: false, focus: true});
 	}
 
-	onChange = (albumName) => (ev) => {
-		const album = ev.value || albumName;
+	onChange = ({album}) => {
 		this.props.onChangeAlbum(album);
 	}
 

--- a/pattern-virtualgridlist-api/src/views/MainView.js
+++ b/pattern-virtualgridlist-api/src/views/MainView.js
@@ -26,8 +26,8 @@ class MainView extends React.Component {
 		this.scrollTo({index: 0, animate: false, focus: true});
 	}
 
-	onChange = (ev) => {
-		const album = ev.value;
+	onChange = (albumName) => (ev) => {
+		const album = ev.value || albumName;
 		this.props.onChangeAlbum(album);
 	}
 


### PR DESCRIPTION
When album name is selected, the event handler got only {selected: bool}, and `ev.value` was getting undefined. Fixed this issue with declaring the album toggle handler with the album name so that it can be used when the other album name is selected.