### PR TITLE
ENYO-6000: Fix layout sample to display images when returning to main panel

### DIFF
--- a/pattern-layout/src/components/util.js
+++ b/pattern-layout/src/components/util.js
@@ -16,7 +16,7 @@ const saveObjToQueryString = (obj) => {
 	Object.keys(allParams).forEach((p) => (allParams[p] == null) && delete allParams[p]);
 
 	const stringified = qs.stringify(allParams);
-	window.history.pushState(obj, '', (stringified ? `?${stringified}` : '/'));
+	window.history.pushState(obj, '', (stringified ? `?${stringified}` : ''));
 };
 
 /*


### PR DESCRIPTION
Previously was using `'/'` history state for base case when no query parameters are being used (when on MainPanel). The absolute URL was causing problems with image loading when served from non-root locations, such as Nebula or subdirectories.

Using an empty string location as base case acts as a relative alternative and avoiding changing the URL path itself.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>