### PR TITLE
PLAT-83930: Update Enact Samples to use 3.x

### DIFF
--- a/enact-all-samples/package.json
+++ b/enact-all-samples/package.json
@@ -30,12 +30,12 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
-    "@enact/webos": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
+    "@enact/webos": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "query-string": "^6.4.0",

--- a/my-theme-app/package.json
+++ b/my-theme-app/package.json
@@ -1,46 +1,46 @@
 {
-	"name": "my-theme-app",
-	"version": "1.0.0",
-	"description": "A demonstration of a 'my-theme' application.",
-	"author": "",
-	"main": "src/index.js",
-	"scripts": {
-		"serve": "enact serve",
-		"pack": "enact pack",
-		"pack-p": "enact pack -p",
-		"watch": "enact pack --watch",
-		"clean": "enact clean",
-		"lint": "enact lint .",
-		"license": "enact license",
-		"test": "enact test",
-		"test-watch": "enact test --watch"
-	},
-	"license": "UNLICENSED",
-	"private": true,
-	"repository": "",
-	"enact": {
-		"theme": "my-theme",
-		"ri": {
-			"baseSize": 24
-		}
-	},
-	"eslintConfig": {
-		"extends": "enact"
-	},
-	"eslintIgnore": [
-		"node_modules/*",
-		"build/*",
-		"dist/*"
-	],
-	"dependencies": {
-		"@enact/core": "next",
-		"@enact/i18n": "next",
-		"@enact/my-theme": "enactjs/my-theme#develop",
-		"@enact/spotlight": "next",
-		"@enact/ui": "next",
-		"ilib": "^14.2.0",
-		"prop-types": "^15.6.2",
-		"react": "^16.7.0",
-		"react-dom": "^16.7.0"
-	}
+  "name": "my-theme-app",
+  "version": "1.0.0",
+  "description": "A demonstration of a 'my-theme' application.",
+  "author": "",
+  "main": "src/index.js",
+  "scripts": {
+    "serve": "enact serve",
+    "pack": "enact pack",
+    "pack-p": "enact pack -p",
+    "watch": "enact pack --watch",
+    "clean": "enact clean",
+    "lint": "enact lint .",
+    "license": "enact license",
+    "test": "enact test",
+    "test-watch": "enact test --watch"
+  },
+  "license": "UNLICENSED",
+  "private": true,
+  "repository": "",
+  "enact": {
+    "theme": "my-theme",
+    "ri": {
+      "baseSize": 24
+    }
+  },
+  "eslintConfig": {
+    "extends": "enact"
+  },
+  "eslintIgnore": [
+    "node_modules/*",
+    "build/*",
+    "dist/*"
+  ],
+  "dependencies": {
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/my-theme": "enactjs/my-theme#develop",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
+    "ilib": "^14.2.0",
+    "prop-types": "^15.6.2",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
+  }
 }

--- a/pattern-activity-panels-deep-linking/package.json
+++ b/pattern-activity-panels-deep-linking/package.json
@@ -30,11 +30,11 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-activity-panels-redux/package.json
+++ b/pattern-activity-panels-redux/package.json
@@ -30,11 +30,11 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-activity-panels/package.json
+++ b/pattern-activity-panels/package.json
@@ -30,11 +30,11 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-analytics-webostv/package.json
+++ b/pattern-analytics-webostv/package.json
@@ -28,12 +28,12 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/analytics": "^1.0.0-beta.1",
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
+    "@enact/analytics": "^1.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-analytics/package.json
+++ b/pattern-analytics/package.json
@@ -28,12 +28,12 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/analytics": "^1.0.0-beta.1",
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
+    "@enact/analytics": "^1.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-dynamic-panel/package.json
+++ b/pattern-dynamic-panel/package.json
@@ -30,12 +30,12 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
-    "@enact/webos": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
+    "@enact/webos": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-expandablelist-object/package.json
+++ b/pattern-expandablelist-object/package.json
@@ -30,11 +30,11 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-layout/package.json
+++ b/pattern-layout/package.json
@@ -28,12 +28,12 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
-    "@enact/webos": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
+    "@enact/webos": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.2",
     "query-string": "^6.4.0",

--- a/pattern-layout/src/views/FavoritesList.js
+++ b/pattern-layout/src/views/FavoritesList.js
@@ -4,7 +4,7 @@ import kind from '@enact/core/kind';
 import {Cell, Column, Row} from '@enact/ui/Layout';
 import ri from '@enact/ui/resolution';
 import {SpotlightContainerDecorator} from '@enact/spotlight/SpotlightContainerDecorator';
-import Divider from '@enact/moonstone/Divider';
+import Heading from '@enact/moonstone/Heading';
 import IconButton from '@enact/moonstone/IconButton';
 import Item from '@enact/moonstone/Item';
 import {Panel, Header} from '@enact/moonstone/Panels';
@@ -54,7 +54,7 @@ const ItemPanel = kind({
 				<Cell>
 					<Column>
 						<Cell shrink>
-							<Divider>All Items</Divider>
+							<Heading showLine>All Items</Heading>
 						</Cell>
 						<Cell>
 							<VirtualList
@@ -73,7 +73,7 @@ const ItemPanel = kind({
 					</Column>
 				</Cell>
 				<Cell>
-					<Divider>Selected Items</Divider>
+					<Heading showLine>Selected Items</Heading>
 					<Item>Item 1</Item>
 					<Item>Item 2</Item>
 				</Cell>

--- a/pattern-list-details-redux/README.md
+++ b/pattern-list-details-redux/README.md
@@ -12,7 +12,7 @@ Run `npm install` then
 `npm run serve` to have the app running on [http://localhost:8080](http://localhost:8080), where you can view it in your browser.
 
 #### Enact Components used
-- `moonstone/Divider`
+- `moonstone/Heading`
 - `moonstone/IconButton`
 - `moonstone/Image`
 - `moonstone/CheckboxItem`

--- a/pattern-list-details-redux/package.json
+++ b/pattern-list-details-redux/package.json
@@ -30,11 +30,11 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-list-details/README.md
+++ b/pattern-list-details/README.md
@@ -10,7 +10,7 @@ Run `npm install` then
 `npm run serve` to have the app running on [http://localhost:8080](http://localhost:8080), where you can view it in your browser.
 
 #### Enact Components used
-- `moonstone/Divider`
+- `moonstone/Heading`
 - `moonstone/IconButton`
 - `moonstone/Image`
 - `moonstone/SelectableItem`

--- a/pattern-list-details/package.json
+++ b/pattern-list-details/package.json
@@ -30,11 +30,11 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-locale-switching/package.json
+++ b/pattern-locale-switching/package.json
@@ -30,12 +30,12 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
-    "@enact/webos": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
+    "@enact/webos": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-ls2request/package.json
+++ b/pattern-ls2request/package.json
@@ -30,12 +30,12 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
-    "@enact/webos": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
+    "@enact/webos": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-routable-panels/package.json
+++ b/pattern-routable-panels/package.json
@@ -30,11 +30,11 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-single-panel-redux/package.json
+++ b/pattern-single-panel-redux/package.json
@@ -30,11 +30,11 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-single-panel/package.json
+++ b/pattern-single-panel/package.json
@@ -30,11 +30,11 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-video-player/package.json
+++ b/pattern-video-player/package.json
@@ -30,11 +30,11 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-virtualgridlist-api/package.json
+++ b/pattern-virtualgridlist-api/package.json
@@ -30,11 +30,11 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/pattern-virtuallist-preserving-focus/package.json
+++ b/pattern-virtuallist-preserving-focus/package.json
@@ -30,11 +30,11 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/tutorial-hello-enact/package.json
+++ b/tutorial-hello-enact/package.json
@@ -30,11 +30,11 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",

--- a/tutorial-kitten-browser/package.json
+++ b/tutorial-kitten-browser/package.json
@@ -30,12 +30,12 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "@enact/core": "^2.0.0",
-    "@enact/i18n": "^2.0.0",
-    "@enact/moonstone": "^2.0.0",
-    "@enact/spotlight": "^2.0.0",
-    "@enact/ui": "^2.0.0",
-    "@enact/webos": "^2.0.0",
+    "@enact/core": "^3.0.0-beta.1",
+    "@enact/i18n": "^3.0.0-beta.1",
+    "@enact/moonstone": "^3.0.0-beta.1",
+    "@enact/spotlight": "^3.0.0-beta.1",
+    "@enact/ui": "^3.0.0-beta.1",
+    "@enact/webos": "^3.0.0-beta.1",
     "ilib": "^14.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.7.0",


### PR DESCRIPTION
Updates all internal samples to use Enact 3.x prerelease dependencies.
Replaced with `Heading showLine` like other examples/samples.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>