### PR TITLE
PLAT-100424: Fix lint errors in enact samples

### DIFF
--- a/pattern-expandablelist-object/src/views/MainPanel.js
+++ b/pattern-expandablelist-object/src/views/MainPanel.js
@@ -1,10 +1,19 @@
 import ExpandableList from '@enact/moonstone/ExpandableList';
 import {Header, Panel} from '@enact/moonstone/Panels';
 import kind from '@enact/core/kind';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const MainPanel = kind({
 	name: 'MainPanel',
+
+	propTypes: {
+		/**
+		 * The title to display in the header.
+		 * @type {String}
+		 */
+		title: PropTypes.string
+	},
 
 	render: (props) => (
 		<Panel {...props}>
@@ -15,9 +24,9 @@ const MainPanel = kind({
 				title={'ExpandableList with Data in Object format'}
 			>
 				{[
-					{disabled:false, children: 'option1', key: 'option1'},
-					{disabled:false, children: 'option2', key: 'option2'},
-					{disabled:true, children: 'option3', key: 'option3'}
+					{disabled: false, children: 'option1', key: 'option1'},
+					{disabled: false, children: 'option2', key: 'option2'},
+					{disabled: true, children: 'option3', key: 'option3'}
 				]}
 			</ExpandableList>
 		</Panel>

--- a/pattern-layout/src/views/MainPanel.js
+++ b/pattern-layout/src/views/MainPanel.js
@@ -10,7 +10,8 @@ const GridItem = kind({
 	name: 'GridItem',
 	propTypes: {
 		index: PropTypes.number,
-		items: PropTypes.array
+		items: PropTypes.array,
+		onSelect: PropTypes.function
 	},
 	handlers: {
 		onSelect: (ev, {index, onSelect}) => onSelect({index})


### PR DESCRIPTION
Adds missing `propTypes` to some samples to keep Travis from complaining.