### PR TITLE
WRN-3524: Fixed all-samples not to lose focus when navigating to each sample through all-samples menu

### DIFF
--- a/sandstone/all-samples/src/App/App.js
+++ b/sandstone/all-samples/src/App/App.js
@@ -1,13 +1,27 @@
 import kind from '@enact/core/kind';
+import Scroller from '@enact/sandstone/Scroller';
+
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
 import PropTypes from 'prop-types';
-import {routes} from  '../index';
+import {HashRouter as Router, Route} from 'react-router-dom';
+
 import SampleItem from '../components/SampleItem';
-import Scroller from '@enact/sandstone/Scroller';
+import ButtonToSamples from '../components/ButtonToSamples';
+import {AppBase as PatternDynamicPanel} from '../../../pattern-dynamic-panel/src/App/App';
+import {AppBase as PatternLayout} from '../../../pattern-layout/src/App/App';
+import {appElementBase as PatternLocaleSwitching} from '../../../pattern-locale-switching/src/main';
+import {appElementBase as PatternRoutablePanels} from '../../../pattern-routable-panels/src/main';
+import {AppBase as PatternSinglePanel} from '../../../pattern-single-panel/src/App/App';
+import {appElementBase as PatternSinglePanelRedux} from '../../../pattern-single-panel-redux/src/main';
+import {AppBase as PatternVideoPlayer} from '../../../pattern-video-player/src/App/App';
+import {appElementBase as PatternVirtualgridlistApi} from '../../../pattern-virtualgridlist-api/src/main';
+import {appElementBase as PatternVirtuallistPreservingFocus} from '../../../pattern-virtuallist-preserving-focus/src/main';
+import {AppBase as TutorialHelloEnact} from '../../../tutorial-hello-enact/src/App/App';
+import {AppBase as TutorialKittenBrowser} from '../../../tutorial-kitten-browser/src/App/App';
 
 import css from './App.module.less';
 
-const App = kind({
+const NavigationMenu = kind({
 	name: 'App',
 
 	propTypes: {
@@ -17,11 +31,6 @@ const App = kind({
 		staticContext: PropTypes.any
 	},
 
-	styles: {
-		css,
-		className: 'app'
-	},
-
 	render: ({history, ...props}) => {
 		delete props.match;
 		delete props.location;
@@ -29,8 +38,9 @@ const App = kind({
 
 		return (
 			<div {...props}>
-				<Scroller>
-					{routes.map(({path}, index) => {
+				{
+					// eslint-disable-next-line no-use-before-define
+					routes.map(({path}, index) => {
 						if (path !== '/') {
 							return (
 								<SampleItem key={index} path={path} history={history}>
@@ -39,11 +49,51 @@ const App = kind({
 							);
 						}
 						return null;
-					})}
+					})
+				}
+			</div>
+		);
+	}
+});
+
+const routes = [
+	{path: '/', exact: true, component: NavigationMenu},
+	{path: '/PatternDynamicPanel', component: PatternDynamicPanel},
+	{path: '/PatternLayout', component: PatternLayout},
+	{path: '/PatternLocaleSwitching', component: PatternLocaleSwitching},
+	{path: '/PatternRoutablePanels', component: PatternRoutablePanels},
+	{path: '/PatternSinglePanel', component: PatternSinglePanel},
+	{path: '/PatternSinglePanelRedux', component: PatternSinglePanelRedux},
+	{path: '/PatternVideoPlayer', component: PatternVideoPlayer},
+	{path: '/PatternVirtualgridlistApi', component: PatternVirtualgridlistApi},
+	{path: '/PatternVirtuallistPreservingFocus', component: PatternVirtuallistPreservingFocus},
+	{path: '/TutorialHelloEnact', component: TutorialHelloEnact},
+	{path: '/TutorialKittenBrowser', component: TutorialKittenBrowser}
+];
+
+const AppBase = kind({
+	name: 'App',
+
+	styles: {
+		css,
+		className: 'app'
+	},
+
+	render: (props) => {
+		return (
+			<div {...props}>
+				<Scroller>
+					<Router>
+						<div>
+							<ButtonToSamples />
+							{routes.map((route, index) => <Route key={index} {...route} />)}
+						</div>
+					</Router>
 				</Scroller>
 			</div>
 		);
 	}
 });
 
-export default ThemeDecorator(App);
+const App = ThemeDecorator(AppBase);
+export default App;

--- a/sandstone/all-samples/src/App/App.js
+++ b/sandstone/all-samples/src/App/App.js
@@ -1,16 +1,11 @@
 import kind from '@enact/core/kind';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
-import Spotlight from '@enact/spotlight';
 import PropTypes from 'prop-types';
 import {routes} from  '../index';
 import SampleItem from '../components/SampleItem';
 import Scroller from '@enact/sandstone/Scroller';
 
 import css from './App.module.less';
-
-const forceFocusElement = () => {
-	Spotlight.initialize();
-};
 
 const App = kind({
 	name: 'App',
@@ -28,8 +23,6 @@ const App = kind({
 	},
 
 	render: ({history, ...props}) => {
-		setTimeout(forceFocusElement, 100);
-
 		delete props.match;
 		delete props.location;
 		delete props.staticContext;

--- a/sandstone/all-samples/src/App/App.js
+++ b/sandstone/all-samples/src/App/App.js
@@ -1,11 +1,16 @@
 import kind from '@enact/core/kind';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
+import Spotlight from '@enact/spotlight';
 import PropTypes from 'prop-types';
 import {routes} from  '../index';
 import SampleItem from '../components/SampleItem';
 import Scroller from '@enact/sandstone/Scroller';
 
 import css from './App.module.less';
+
+const forceFocusElement = () => {
+	Spotlight.initialize();
+};
 
 const App = kind({
 	name: 'App',
@@ -23,6 +28,8 @@ const App = kind({
 	},
 
 	render: ({history, ...props}) => {
+		setTimeout(forceFocusElement, 100);
+
 		delete props.match;
 		delete props.location;
 		delete props.staticContext;

--- a/sandstone/all-samples/src/App/App.js
+++ b/sandstone/all-samples/src/App/App.js
@@ -1,6 +1,5 @@
 import kind from '@enact/core/kind';
 import Scroller from '@enact/sandstone/Scroller';
-
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
 import PropTypes from 'prop-types';
 import {HashRouter as Router, Route} from 'react-router-dom';
@@ -37,20 +36,22 @@ const NavigationMenu = kind({
 		delete props.staticContext;
 
 		return (
-			<div {...props}>
-				{
-					// eslint-disable-next-line no-use-before-define
-					routes.map(({path}, index) => {
-						if (path !== '/') {
-							return (
-								<SampleItem key={index} path={path} history={history}>
-									{path.substr(1)}
-								</SampleItem>
-							);
-						}
-						return null;
-					})
-				}
+			<div {...props} style={{height: '90%'}}>
+				<Scroller>
+					{
+						// eslint-disable-next-line no-use-before-define
+						routes.map(({path}, index) => {
+							if (path !== '/') {
+								return (
+									<SampleItem key={index} path={path} history={history}>
+										{path.substr(1)}
+									</SampleItem>
+								);
+							}
+							return null;
+						})
+					}
+				</Scroller>
 			</div>
 		);
 	}
@@ -81,16 +82,12 @@ const AppBase = kind({
 
 	render: (props) => {
 		return (
-			<div {...props}>
-				<Scroller>
-					<Router>
-						<div>
-							<ButtonToSamples />
-							{routes.map((route, index) => <Route key={index} {...route} />)}
-						</div>
-					</Router>
-				</Scroller>
-			</div>
+			<Router>
+				<div {...props}>
+					<ButtonToSamples />
+					{routes.map((route, index) => <Route key={index} {...route} />)}
+				</div>
+			</Router>
 		);
 	}
 });

--- a/sandstone/all-samples/src/index.js
+++ b/sandstone/all-samples/src/index.js
@@ -1,36 +1,7 @@
 import 'web-animations-js';
-import {HashRouter as Router, Route} from 'react-router-dom';
 import {render} from 'react-dom';
 
-import PatternDynamicPanel from '../../pattern-dynamic-panel/src/App/App';
-import PatternLayout from '../../pattern-layout/src/App/App';
-import PatternLocaleSwitching from '../../pattern-locale-switching/src/main';
-import PatternRoutablePanels from '../../pattern-routable-panels/src/main';
-import PatternSinglePanel from '../../pattern-single-panel/src/App/App';
-import PatternSinglePanelRedux from '../../pattern-single-panel-redux/src/main';
-import PatternVideoPlayer from '../../pattern-video-player/src/App/App';
-import PatternVirtualgridlistApi from '../../pattern-virtualgridlist-api/src/main';
-import PatternVirtuallistPreservingFocus from '../../pattern-virtuallist-preserving-focus/src/main';
-import TutorialHelloEnact from '../../tutorial-hello-enact/src/App/App';
-import TutorialKittenBrowser from '../../tutorial-kitten-browser/src/App/App';
-
 import App from './App';
-import ButtonToSamples from './components/ButtonToSamples';
-
-export const routes = [
-	{path: '/', exact: true, component: App},
-	{path: '/PatternDynamicPanel', component: PatternDynamicPanel},
-	{path: '/PatternLayout', component: PatternLayout},
-	{path: '/PatternLocaleSwitching', component: PatternLocaleSwitching},
-	{path: '/PatternRoutablePanels', component: PatternRoutablePanels},
-	{path: '/PatternSinglePanel', component: PatternSinglePanel},
-	{path: '/PatternSinglePanelRedux', component: PatternSinglePanelRedux},
-	{path: '/PatternVideoPlayer', component: PatternVideoPlayer},
-	{path: '/PatternVirtualgridlistApi', component: PatternVirtualgridlistApi},
-	{path: '/PatternVirtuallistPreservingFocus', component: PatternVirtuallistPreservingFocus},
-	{path: '/TutorialHelloEnact', component: TutorialHelloEnact},
-	{path: '/TutorialKittenBrowser', component: TutorialKittenBrowser}
-];
 
 // Router causes an error with our samples, but we don't want our samples to know about router.
 // To avoid this for now we're just surpressing the error.
@@ -42,14 +13,7 @@ console.error = (...args) => {
 };
 /* eslint-enable no-console */
 
-const appElement = (
-	<Router>
-		<div>
-			<ButtonToSamples />
-			{routes.map((route, index) => <Route key={index} {...route} />)}
-		</div>
-	</Router>
-);
+const appElement = (<App />);
 
 // In a browser environment, render the app to the document.
 if (typeof window !== 'undefined') {

--- a/sandstone/pattern-dynamic-panel/src/App/App.js
+++ b/sandstone/pattern-dynamic-panel/src/App/App.js
@@ -1,6 +1,5 @@
 import kind from '@enact/core/kind';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
-import Spotlight from '@enact/spotlight';
 import Changeable from '@enact/ui/Changeable';
 
 import FileBrowser from '../components/FileBrowser';
@@ -13,13 +12,6 @@ const Browser = Changeable(
 	FileBrowser
 );
 
-const forceFocusElement = () => {
-	if (!Spotlight.getCurrent()) {
-		Spotlight.focus();
-		Spotlight.initialize();
-	}
-};
-
 const App = kind({
 	name: 'App',
 
@@ -28,15 +20,11 @@ const App = kind({
 		className: 'app'
 	},
 
-	render: (props) => {
-		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
-		setTimeout(forceFocusElement, 100);
-		return (
-			<div {...props}>
-				<Browser defaultPath={{path: '/a', directory: true}} />
-			</div>
-		);
-	}
+	render: (props) => (
+		<div {...props}>
+			<Browser defaultPath={{path: '/a', directory: true}} />
+		</div>
+	)
 });
 
 export default ThemeDecorator(App);

--- a/sandstone/pattern-dynamic-panel/src/App/App.js
+++ b/sandstone/pattern-dynamic-panel/src/App/App.js
@@ -12,7 +12,7 @@ const Browser = Changeable(
 	FileBrowser
 );
 
-const App = kind({
+const AppBase = kind({
 	name: 'App',
 
 	styles: {
@@ -27,4 +27,7 @@ const App = kind({
 	)
 });
 
-export default ThemeDecorator(App);
+const App = ThemeDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/sandstone/pattern-dynamic-panel/src/App/App.js
+++ b/sandstone/pattern-dynamic-panel/src/App/App.js
@@ -1,5 +1,6 @@
 import kind from '@enact/core/kind';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
+import Spotlight from '@enact/spotlight';
 import Changeable from '@enact/ui/Changeable';
 
 import FileBrowser from '../components/FileBrowser';
@@ -12,6 +13,13 @@ const Browser = Changeable(
 	FileBrowser
 );
 
+const forceFocusElement = () => {
+	if (!Spotlight.getCurrent()) {
+		Spotlight.focus();
+		Spotlight.initialize();
+	}
+};
+
 const App = kind({
 	name: 'App',
 
@@ -20,11 +28,15 @@ const App = kind({
 		className: 'app'
 	},
 
-	render: (props) => (
-		<div {...props}>
-			<Browser defaultPath={{path: '/a', directory: true}} />
-		</div>
-	)
+	render: (props) => {
+		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
+		setTimeout(forceFocusElement, 100);
+		return (
+			<div {...props}>
+				<Browser defaultPath={{path: '/a', directory: true}} />
+			</div>
+		);
+	}
 });
 
 export default ThemeDecorator(App);

--- a/sandstone/pattern-layout/src/App/App.js
+++ b/sandstone/pattern-layout/src/App/App.js
@@ -5,7 +5,6 @@ import Button from '@enact/sandstone/Button';
 import {Panels} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
 import PropTypes from 'prop-types';
-import compose from 'ramda/src/compose';
 import {Component} from 'react';
 
 import {importAll} from '../components/util';
@@ -32,7 +31,7 @@ itemPusher('Details View', 'Show off details about an item', Details, thumbs['de
 
 const Placeholder = kind({name: 'Placeholder'});
 
-const _AppBase = kind({
+const Sample = kind({
 	name: 'LayoutApp',
 
 	propTypes: {
@@ -138,11 +137,8 @@ const AppDecorator = hoc((config, Wrapped) => {
 	};
 });
 
-const AppBase = AppDecorator(_AppBase);
-const App = compose(
-	ThemeDecorator,
-	AppDecorator
-)(_AppBase);
+const AppBase = AppDecorator(Sample);
+const App = ThemeDecorator(AppBase);
 
 export default App;
 export {App, AppBase};

--- a/sandstone/pattern-layout/src/App/App.js
+++ b/sandstone/pattern-layout/src/App/App.js
@@ -32,7 +32,7 @@ itemPusher('Details View', 'Show off details about an item', Details, thumbs['de
 
 const Placeholder = kind({name: 'Placeholder'});
 
-const App = kind({
+const _AppBase = kind({
 	name: 'LayoutApp',
 
 	propTypes: {
@@ -138,7 +138,11 @@ const AppDecorator = hoc((config, Wrapped) => {
 	};
 });
 
-export default compose(
+const AppBase = AppDecorator(_AppBase);
+const App = compose(
 	ThemeDecorator,
 	AppDecorator
-)(App);
+)(_AppBase);
+
+export default App;
+export {App, AppBase};

--- a/sandstone/pattern-layout/src/App/App.js
+++ b/sandstone/pattern-layout/src/App/App.js
@@ -4,7 +4,6 @@ import kind from '@enact/core/kind';
 import Button from '@enact/sandstone/Button';
 import {Panels} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
-import Spotlight from '@enact/spotlight';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import {Component} from 'react';
@@ -30,13 +29,6 @@ const itemPusher = (title, subTitle, component, image) => {
 // Add all of our Layout Patterns
 itemPusher('Favorites List', 'Two list columns with focusable buttons in the center', FavoritesList, thumbs['favorites-list.jpg']);
 itemPusher('Details View', 'Show off details about an item', Details, thumbs['details.jpg']);
-
-const forceFocusElement = () => {
-	if (!Spotlight.getCurrent()) {
-		Spotlight.focus();
-		Spotlight.initialize();
-	}
-};
 
 const Placeholder = kind({name: 'Placeholder'});
 
@@ -65,9 +57,6 @@ const App = kind({
 	},
 
 	render: ({debug, DebugButton, itemIndex, onChangePanel, onSelectBreadcrumb, ...rest}) => {
-		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
-		setTimeout(forceFocusElement, 100);
-
 		delete rest.onToggleDebug;
 
 		let secondaryPanel = <Placeholder />;

--- a/sandstone/pattern-layout/src/App/App.js
+++ b/sandstone/pattern-layout/src/App/App.js
@@ -4,6 +4,7 @@ import kind from '@enact/core/kind';
 import Button from '@enact/sandstone/Button';
 import {Panels} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
+import Spotlight from '@enact/spotlight';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import {Component} from 'react';
@@ -29,6 +30,13 @@ const itemPusher = (title, subTitle, component, image) => {
 // Add all of our Layout Patterns
 itemPusher('Favorites List', 'Two list columns with focusable buttons in the center', FavoritesList, thumbs['favorites-list.jpg']);
 itemPusher('Details View', 'Show off details about an item', Details, thumbs['details.jpg']);
+
+const forceFocusElement = () => {
+	if (!Spotlight.getCurrent()) {
+		Spotlight.focus();
+		Spotlight.initialize();
+	}
+};
 
 const Placeholder = kind({name: 'Placeholder'});
 
@@ -57,6 +65,9 @@ const App = kind({
 	},
 
 	render: ({debug, DebugButton, itemIndex, onChangePanel, onSelectBreadcrumb, ...rest}) => {
+		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
+		setTimeout(forceFocusElement, 100);
+
 		delete rest.onToggleDebug;
 
 		let secondaryPanel = <Placeholder />;

--- a/sandstone/pattern-locale-switching/src/App/App.js
+++ b/sandstone/pattern-locale-switching/src/App/App.js
@@ -1,11 +1,19 @@
 import kind from '@enact/core/kind';
 import {Panels} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
+import Spotlight from '@enact/spotlight';
 import {connect} from 'react-redux';
 
 import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
+
+const forceFocusElement = () => {
+	if (!Spotlight.getCurrent()) {
+		Spotlight.focus();
+		Spotlight.initialize();
+	}
+};
 
 const App = kind({
 	name: 'App',
@@ -16,6 +24,8 @@ const App = kind({
 	},
 
 	render: (props) => {
+		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
+		setTimeout(forceFocusElement, 100);
 		return (
 			<div {...props}>
 				<Panels>

--- a/sandstone/pattern-locale-switching/src/App/App.js
+++ b/sandstone/pattern-locale-switching/src/App/App.js
@@ -7,7 +7,7 @@ import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
 
-const App = kind({
+const _AppBase = kind({
 	name: 'App',
 
 	styles: {
@@ -28,4 +28,8 @@ const App = kind({
 
 const mapStateToProps = ({locale}) => ({locale});
 
-export default connect(mapStateToProps, {})(ThemeDecorator(App));
+const AppBase = connect(mapStateToProps, {})(_AppBase);
+const App = connect(mapStateToProps, {})(ThemeDecorator(_AppBase));
+
+export default App;
+export {App, AppBase};

--- a/sandstone/pattern-locale-switching/src/App/App.js
+++ b/sandstone/pattern-locale-switching/src/App/App.js
@@ -7,7 +7,7 @@ import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
 
-const _AppBase = kind({
+const Sample = kind({
 	name: 'App',
 
 	styles: {
@@ -28,8 +28,8 @@ const _AppBase = kind({
 
 const mapStateToProps = ({locale}) => ({locale});
 
-const AppBase = connect(mapStateToProps, {})(_AppBase);
-const App = connect(mapStateToProps, {})(ThemeDecorator(_AppBase));
+const AppBase = connect(mapStateToProps, {})(Sample);
+const App = connect(mapStateToProps, {})(ThemeDecorator(Sample));
 
 export default App;
 export {App, AppBase};

--- a/sandstone/pattern-locale-switching/src/App/App.js
+++ b/sandstone/pattern-locale-switching/src/App/App.js
@@ -1,19 +1,11 @@
 import kind from '@enact/core/kind';
 import {Panels} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
-import Spotlight from '@enact/spotlight';
 import {connect} from 'react-redux';
 
 import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
-
-const forceFocusElement = () => {
-	if (!Spotlight.getCurrent()) {
-		Spotlight.focus();
-		Spotlight.initialize();
-	}
-};
 
 const App = kind({
 	name: 'App',
@@ -24,8 +16,6 @@ const App = kind({
 	},
 
 	render: (props) => {
-		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
-		setTimeout(forceFocusElement, 100);
 		return (
 			<div {...props}>
 				<Panels>

--- a/sandstone/pattern-locale-switching/src/main.js
+++ b/sandstone/pattern-locale-switching/src/main.js
@@ -1,10 +1,16 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
 const store = configureStore();
+
+let appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
 
 let appElement = () => (
 	<Provider store={store}>
@@ -13,3 +19,4 @@ let appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/sandstone/pattern-routable-panels/src/App/App.js
+++ b/sandstone/pattern-routable-panels/src/App/App.js
@@ -11,7 +11,7 @@ import AppStateDecorator from './AppStateDecorator';
 
 const RoutablePanels = Routable({navigate: 'onBack'}, Panels);
 
-const App = kind({
+const _AppBase = kind({
 	name: 'App',
 
 	propTypes: {
@@ -40,8 +40,8 @@ const App = kind({
 	}
 });
 
-export default ThemeDecorator(
-	AppStateDecorator(
-		App
-	)
-);
+const AppBase = AppStateDecorator(_AppBase);
+const App = ThemeDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/sandstone/pattern-routable-panels/src/App/App.js
+++ b/sandstone/pattern-routable-panels/src/App/App.js
@@ -11,7 +11,7 @@ import AppStateDecorator from './AppStateDecorator';
 
 const RoutablePanels = Routable({navigate: 'onBack'}, Panels);
 
-const _AppBase = kind({
+const Sample = kind({
 	name: 'App',
 
 	propTypes: {
@@ -40,7 +40,7 @@ const _AppBase = kind({
 	}
 });
 
-const AppBase = AppStateDecorator(_AppBase);
+const AppBase = AppStateDecorator(Sample);
 const App = ThemeDecorator(AppBase);
 
 export default App;

--- a/sandstone/pattern-routable-panels/src/App/App.js
+++ b/sandstone/pattern-routable-panels/src/App/App.js
@@ -1,7 +1,6 @@
 import kind from '@enact/core/kind';
 import {Panels, Routable, Route} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
-import Spotlight from '@enact/spotlight';
 import {SlideLeftArranger} from '@enact/ui/ViewManager';
 import PropTypes from 'prop-types';
 
@@ -11,13 +10,6 @@ import MainPanel from '../views/MainPanel';
 import AppStateDecorator from './AppStateDecorator';
 
 const RoutablePanels = Routable({navigate: 'onBack'}, Panels);
-
-const forceFocusElement = () => {
-	if (!Spotlight.getCurrent()) {
-		Spotlight.focus();
-		Spotlight.initialize();
-	}
-};
 
 const App = kind({
 	name: 'App',
@@ -35,8 +27,6 @@ const App = kind({
 	},
 
 	render: ({onFirstPanel, onFourthPanel, onNavigate, onSecondPanel, onThirdPanel, path, ...rest}) => {
-		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
-		setTimeout(forceFocusElement, 100);
 		return (
 			<RoutablePanels {...rest} arranger={SlideLeftArranger} onBack={onNavigate} path={path}>
 				<Route component={AboutPanel} onClick={onSecondPanel} path="first" title="About Routable Panels Pattern">

--- a/sandstone/pattern-routable-panels/src/App/App.js
+++ b/sandstone/pattern-routable-panels/src/App/App.js
@@ -1,6 +1,7 @@
 import kind from '@enact/core/kind';
 import {Panels, Routable, Route} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
+import Spotlight from '@enact/spotlight';
 import {SlideLeftArranger} from '@enact/ui/ViewManager';
 import PropTypes from 'prop-types';
 
@@ -10,6 +11,13 @@ import MainPanel from '../views/MainPanel';
 import AppStateDecorator from './AppStateDecorator';
 
 const RoutablePanels = Routable({navigate: 'onBack'}, Panels);
+
+const forceFocusElement = () => {
+	if (!Spotlight.getCurrent()) {
+		Spotlight.focus();
+		Spotlight.initialize();
+	}
+};
 
 const App = kind({
 	name: 'App',
@@ -27,6 +35,8 @@ const App = kind({
 	},
 
 	render: ({onFirstPanel, onFourthPanel, onNavigate, onSecondPanel, onThirdPanel, path, ...rest}) => {
+		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
+		setTimeout(forceFocusElement, 100);
 		return (
 			<RoutablePanels {...rest} arranger={SlideLeftArranger} onBack={onNavigate} path={path}>
 				<Route component={AboutPanel} onClick={onSecondPanel} path="first" title="About Routable Panels Pattern">

--- a/sandstone/pattern-routable-panels/src/main.js
+++ b/sandstone/pattern-routable-panels/src/main.js
@@ -1,10 +1,16 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
 const store = configureStore();
+
+let appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
 
 let appElement = () => (
 	<Provider store={store}>
@@ -13,3 +19,4 @@ let appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/sandstone/pattern-single-panel-redux/src/App/App.js
+++ b/sandstone/pattern-single-panel-redux/src/App/App.js
@@ -1,18 +1,10 @@
 import kind from '@enact/core/kind';
 import {Panels} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
-import Spotlight from '@enact/spotlight';
 
 import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
-
-const forceFocusElement = () => {
-	if (!Spotlight.getCurrent()) {
-		Spotlight.focus();
-		Spotlight.initialize();
-	}
-};
 
 const App = kind({
 	name: 'App',
@@ -22,15 +14,11 @@ const App = kind({
 		className: 'app'
 	},
 
-	render: (props) => {
-		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
-		setTimeout(forceFocusElement, 100);
-		return (
-			<Panels {...props}>
-				<MainPanel />
-			</Panels>
-		);
-	}
+	render: (props) => (
+		<Panels {...props}>
+			<MainPanel />
+		</Panels>
+	)
 });
 
 export default ThemeDecorator(App);

--- a/sandstone/pattern-single-panel-redux/src/App/App.js
+++ b/sandstone/pattern-single-panel-redux/src/App/App.js
@@ -6,7 +6,7 @@ import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
 
-const App = kind({
+const AppBase = kind({
 	name: 'App',
 
 	styles: {
@@ -21,4 +21,7 @@ const App = kind({
 	)
 });
 
-export default ThemeDecorator(App);
+const App = ThemeDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/sandstone/pattern-single-panel-redux/src/App/App.js
+++ b/sandstone/pattern-single-panel-redux/src/App/App.js
@@ -1,10 +1,18 @@
 import kind from '@enact/core/kind';
 import {Panels} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
+import Spotlight from '@enact/spotlight';
 
 import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
+
+const forceFocusElement = () => {
+	if (!Spotlight.getCurrent()) {
+		Spotlight.focus();
+		Spotlight.initialize();
+	}
+};
 
 const App = kind({
 	name: 'App',
@@ -14,11 +22,15 @@ const App = kind({
 		className: 'app'
 	},
 
-	render: (props) => (
-		<Panels {...props}>
-			<MainPanel />
-		</Panels>
-	)
+	render: (props) => {
+		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
+		setTimeout(forceFocusElement, 100);
+		return (
+			<Panels {...props}>
+				<MainPanel />
+			</Panels>
+		);
+	}
 });
 
 export default ThemeDecorator(App);

--- a/sandstone/pattern-single-panel-redux/src/main.js
+++ b/sandstone/pattern-single-panel-redux/src/main.js
@@ -1,10 +1,16 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
 const store = configureStore();
+
+let appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
 
 let appElement = () => (
 	<Provider store={store}>
@@ -13,3 +19,4 @@ let appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/sandstone/pattern-single-panel/src/App/App.js
+++ b/sandstone/pattern-single-panel/src/App/App.js
@@ -1,18 +1,10 @@
 import kind from '@enact/core/kind';
 import {Panels} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
-import Spotlight from '@enact/spotlight';
 
 import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
-
-const forceFocusElement = () => {
-	if (!Spotlight.getCurrent()) {
-		Spotlight.focus();
-		Spotlight.initialize();
-	}
-};
 
 const App = kind({
 	name: 'App',
@@ -22,15 +14,11 @@ const App = kind({
 		className: 'app'
 	},
 
-	render: (props) => {
-		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
-		setTimeout(forceFocusElement, 100);
-		return (
-			<Panels {...props}>
-				<MainPanel />
-			</Panels>
-		);
-	}
+	render: (props) => (
+		<Panels {...props}>
+			<MainPanel />
+		</Panels>
+	)
 });
 
 export default ThemeDecorator(App);

--- a/sandstone/pattern-single-panel/src/App/App.js
+++ b/sandstone/pattern-single-panel/src/App/App.js
@@ -6,7 +6,7 @@ import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
 
-const App = kind({
+const AppBase = kind({
 	name: 'App',
 
 	styles: {
@@ -21,4 +21,7 @@ const App = kind({
 	)
 });
 
-export default ThemeDecorator(App);
+const App = ThemeDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/sandstone/pattern-single-panel/src/App/App.js
+++ b/sandstone/pattern-single-panel/src/App/App.js
@@ -1,10 +1,18 @@
 import kind from '@enact/core/kind';
 import {Panels} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
+import Spotlight from '@enact/spotlight';
 
 import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
+
+const forceFocusElement = () => {
+	if (!Spotlight.getCurrent()) {
+		Spotlight.focus();
+		Spotlight.initialize();
+	}
+};
 
 const App = kind({
 	name: 'App',
@@ -14,11 +22,15 @@ const App = kind({
 		className: 'app'
 	},
 
-	render: (props) => (
-		<Panels {...props}>
-			<MainPanel />
-		</Panels>
-	)
+	render: (props) => {
+		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
+		setTimeout(forceFocusElement, 100);
+		return (
+			<Panels {...props}>
+				<MainPanel />
+			</Panels>
+		);
+	}
 });
 
 export default ThemeDecorator(App);

--- a/sandstone/pattern-video-player/src/App/App.js
+++ b/sandstone/pattern-video-player/src/App/App.js
@@ -14,6 +14,13 @@ import videos from './videos.js';
 
 import css from './App.module.less';
 
+const forceFocusElement = () => {
+	if (!Spotlight.getCurrent()) {
+		Spotlight.focus();
+		Spotlight.initialize();
+	}
+};
+
 const getVideo = (index) => videos[index];
 
 class App extends Component {
@@ -77,6 +84,9 @@ class App extends Component {
 	};
 
 	render () {
+		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
+		setTimeout(forceFocusElement, 100);
+
 		const {className, ...rest} = this.props;
 		const {source, desc, ...restVideo} = getVideo(this.state.videoIndex);
 		delete rest.panelIndex;

--- a/sandstone/pattern-video-player/src/App/App.js
+++ b/sandstone/pattern-video-player/src/App/App.js
@@ -16,7 +16,7 @@ import css from './App.module.less';
 
 const getVideo = (index) => videos[index];
 
-class App extends Component {
+class AppBase extends Component {
 	static propTypes = {
 		/**
 		 * Assign an alternate panel index to start on.
@@ -118,4 +118,7 @@ class App extends Component {
 	}
 }
 
-export default ThemeDecorator(App);
+const App = ThemeDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/sandstone/pattern-video-player/src/App/App.js
+++ b/sandstone/pattern-video-player/src/App/App.js
@@ -14,13 +14,6 @@ import videos from './videos.js';
 
 import css from './App.module.less';
 
-const forceFocusElement = () => {
-	if (!Spotlight.getCurrent()) {
-		Spotlight.focus();
-		Spotlight.initialize();
-	}
-};
-
 const getVideo = (index) => videos[index];
 
 class App extends Component {
@@ -84,9 +77,6 @@ class App extends Component {
 	};
 
 	render () {
-		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
-		setTimeout(forceFocusElement, 100);
-
 		const {className, ...rest} = this.props;
 		const {source, desc, ...restVideo} = getVideo(this.state.videoIndex);
 		delete rest.panelIndex;

--- a/sandstone/pattern-virtualgridlist-api/src/App/App.js
+++ b/sandstone/pattern-virtualgridlist-api/src/App/App.js
@@ -1,17 +1,9 @@
 import kind from '@enact/core/kind';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
-import Spotlight from '@enact/spotlight';
 
 import MainView from '../views/MainView';
 
 import css from './App.module.less';
-
-const forceFocusElement = () => {
-	if (!Spotlight.getCurrent()) {
-		Spotlight.focus();
-		Spotlight.initialize();
-	}
-};
 
 const App = kind({
 	name: 'App',
@@ -21,15 +13,11 @@ const App = kind({
 		className: 'app'
 	},
 
-	render: (props) => {
-		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
-		setTimeout(forceFocusElement, 100);
-		return (
-			<div {...props}>
-				<MainView />
-			</div>
-		);
-	}
+	render: (props) => (
+		<div {...props}>
+			<MainView />
+		</div>
+	)
 });
 
 export default ThemeDecorator({noAutoFocus: true}, App);

--- a/sandstone/pattern-virtualgridlist-api/src/App/App.js
+++ b/sandstone/pattern-virtualgridlist-api/src/App/App.js
@@ -5,7 +5,7 @@ import MainView from '../views/MainView';
 
 import css from './App.module.less';
 
-const App = kind({
+const AppBase = kind({
 	name: 'App',
 
 	styles: {
@@ -20,4 +20,7 @@ const App = kind({
 	)
 });
 
-export default ThemeDecorator({noAutoFocus: true}, App);
+const App = ThemeDecorator({noAutoFocus: true}, AppBase);
+
+export default App;
+export {App, AppBase};

--- a/sandstone/pattern-virtualgridlist-api/src/App/App.js
+++ b/sandstone/pattern-virtualgridlist-api/src/App/App.js
@@ -1,9 +1,17 @@
 import kind from '@enact/core/kind';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
+import Spotlight from '@enact/spotlight';
 
 import MainView from '../views/MainView';
 
 import css from './App.module.less';
+
+const forceFocusElement = () => {
+	if (!Spotlight.getCurrent()) {
+		Spotlight.focus();
+		Spotlight.initialize();
+	}
+};
 
 const App = kind({
 	name: 'App',
@@ -13,11 +21,15 @@ const App = kind({
 		className: 'app'
 	},
 
-	render: (props) => (
-		<div {...props}>
-			<MainView />
-		</div>
-	)
+	render: (props) => {
+		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
+		setTimeout(forceFocusElement, 100);
+		return (
+			<div {...props}>
+				<MainView />
+			</div>
+		);
+	}
 });
 
 export default ThemeDecorator({noAutoFocus: true}, App);

--- a/sandstone/pattern-virtualgridlist-api/src/App/App.module.less
+++ b/sandstone/pattern-virtualgridlist-api/src/App/App.module.less
@@ -1,4 +1,9 @@
 .app {
-  padding: 0.5rem;
-  box-sizing: border-box;
+	padding: 0.5rem;
+	box-sizing: border-box;
+	position: absolute;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
 }

--- a/sandstone/pattern-virtualgridlist-api/src/main.js
+++ b/sandstone/pattern-virtualgridlist-api/src/main.js
@@ -1,10 +1,16 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
 const store = configureStore();
+
+let appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
 
 let appElement = () => (
 	<Provider store={store}>
@@ -13,3 +19,4 @@ let appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/sandstone/pattern-virtuallist-preserving-focus/src/App/App.js
+++ b/sandstone/pattern-virtuallist-preserving-focus/src/App/App.js
@@ -1,19 +1,11 @@
 import kind from '@enact/core/kind';
 import {Panels} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
-import Spotlight from '@enact/spotlight';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
 import {decreaseIndex, increaseIndex} from '../actions';
 import MainPanel from '../views/MainPanel';
-
-const forceFocusElement = () => {
-	if (!Spotlight.getCurrent()) {
-		Spotlight.focus();
-		Spotlight.initialize();
-	}
-};
 
 const App = kind({
 	name: 'App',
@@ -29,8 +21,6 @@ const App = kind({
 	},
 
 	render: ({index, pushPanel, popPanel, ...rest}) => {
-		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
-		setTimeout(forceFocusElement, 100);
 		return (
 			<Panels {...rest} index={index} onBack={popPanel}>
 				<MainPanel onClick={pushPanel} title="First" />

--- a/sandstone/pattern-virtuallist-preserving-focus/src/App/App.js
+++ b/sandstone/pattern-virtuallist-preserving-focus/src/App/App.js
@@ -7,7 +7,7 @@ import {connect} from 'react-redux';
 import {decreaseIndex, increaseIndex} from '../actions';
 import MainPanel from '../views/MainPanel';
 
-const _AppBase = kind({
+const Sample = kind({
 	name: 'App',
 
 	propTypes: {
@@ -43,7 +43,7 @@ const mapDispatchToProps = (dispatch) => {
 	};
 };
 
-const AppBase = connect(mapStateToProps, mapDispatchToProps)(_AppBase);
+const AppBase = connect(mapStateToProps, mapDispatchToProps)(Sample);
 const App = ThemeDecorator(AppBase);
 
 export default App;

--- a/sandstone/pattern-virtuallist-preserving-focus/src/App/App.js
+++ b/sandstone/pattern-virtuallist-preserving-focus/src/App/App.js
@@ -7,7 +7,7 @@ import {connect} from 'react-redux';
 import {decreaseIndex, increaseIndex} from '../actions';
 import MainPanel from '../views/MainPanel';
 
-const App = kind({
+const _AppBase = kind({
 	name: 'App',
 
 	propTypes: {
@@ -43,4 +43,8 @@ const mapDispatchToProps = (dispatch) => {
 	};
 };
 
-export default ThemeDecorator(connect(mapStateToProps, mapDispatchToProps)(App));
+const AppBase = connect(mapStateToProps, mapDispatchToProps)(_AppBase);
+const App = ThemeDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/sandstone/pattern-virtuallist-preserving-focus/src/App/App.js
+++ b/sandstone/pattern-virtuallist-preserving-focus/src/App/App.js
@@ -1,11 +1,19 @@
 import kind from '@enact/core/kind';
 import {Panels} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
+import Spotlight from '@enact/spotlight';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
 import {decreaseIndex, increaseIndex} from '../actions';
 import MainPanel from '../views/MainPanel';
+
+const forceFocusElement = () => {
+	if (!Spotlight.getCurrent()) {
+		Spotlight.focus();
+		Spotlight.initialize();
+	}
+};
 
 const App = kind({
 	name: 'App',
@@ -21,6 +29,8 @@ const App = kind({
 	},
 
 	render: ({index, pushPanel, popPanel, ...rest}) => {
+		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
+		setTimeout(forceFocusElement, 100);
 		return (
 			<Panels {...rest} index={index} onBack={popPanel}>
 				<MainPanel onClick={pushPanel} title="First" />

--- a/sandstone/pattern-virtuallist-preserving-focus/src/main.js
+++ b/sandstone/pattern-virtuallist-preserving-focus/src/main.js
@@ -1,10 +1,16 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
 const store = configureStore();
+
+const appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
 
 const appElement = () => (
 	<Provider store={store}>
@@ -13,3 +19,4 @@ const appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/sandstone/tutorial-kitten-browser/src/App/App.js
+++ b/sandstone/tutorial-kitten-browser/src/App/App.js
@@ -16,7 +16,7 @@ const kittens = [
 	'Kitty'
 ];
 
-const _AppBase = kind({
+const Sample = kind({
 	name: 'App',
 
 	propTypes: {
@@ -60,7 +60,7 @@ const _AppBase = kind({
 
 const AppBase = Changeable({prop: 'index', change: 'onNavigate'},
 	Changeable({prop: 'kitten', change: 'onSelectKitten'},
-		_AppBase
+		Sample
 	)
 );
 

--- a/sandstone/tutorial-kitten-browser/src/App/App.js
+++ b/sandstone/tutorial-kitten-browser/src/App/App.js
@@ -1,11 +1,19 @@
 import kind from '@enact/core/kind';
 import {Panels} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
+import Spotlight from '@enact/spotlight';
 import Changeable from '@enact/ui/Changeable';
 import PropTypes from 'prop-types';
 
 import Detail from '../views/Detail';
 import List from '../views/List';
+
+const forceFocusElement = () => {
+	if (!Spotlight.getCurrent()) {
+		Spotlight.focus();
+		Spotlight.initialize();
+	}
+};
 
 const kittens = [
 	'Garfield',
@@ -48,14 +56,18 @@ const AppBase = kind({
 		}
 	},
 
-	render: ({index, kitten, onNavigate, onSelectKitten, ...rest}) => (
-		<div {...rest}>
-			<Panels index={index} onBack={onNavigate}>
-				<List onSelectKitten={onSelectKitten}>{kittens}</List>
-				<Detail name={kittens[kitten]} />
-			</Panels>
-		</div>
-	)
+	render: ({index, kitten, onNavigate, onSelectKitten, ...rest}) => {
+		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
+		setTimeout(forceFocusElement, 100);
+		return (
+			<div {...rest}>
+				<Panels index={index} onBack={onNavigate}>
+					<List onSelectKitten={onSelectKitten}>{kittens}</List>
+					<Detail name={kittens[kitten]} />
+				</Panels>
+			</div>
+		);
+	}
 });
 
 const App = Changeable({prop: 'index', change: 'onNavigate'},

--- a/sandstone/tutorial-kitten-browser/src/App/App.js
+++ b/sandstone/tutorial-kitten-browser/src/App/App.js
@@ -1,19 +1,11 @@
 import kind from '@enact/core/kind';
 import {Panels} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
-import Spotlight from '@enact/spotlight';
 import Changeable from '@enact/ui/Changeable';
 import PropTypes from 'prop-types';
 
 import Detail from '../views/Detail';
 import List from '../views/List';
-
-const forceFocusElement = () => {
-	if (!Spotlight.getCurrent()) {
-		Spotlight.focus();
-		Spotlight.initialize();
-	}
-};
 
 const kittens = [
 	'Garfield',
@@ -56,18 +48,14 @@ const AppBase = kind({
 		}
 	},
 
-	render: ({index, kitten, onNavigate, onSelectKitten, ...rest}) => {
-		// In order not to lose focus on the sample when navigating to the sample through all-samples, for now we manually focus the element
-		setTimeout(forceFocusElement, 100);
-		return (
-			<div {...rest}>
-				<Panels index={index} onBack={onNavigate}>
-					<List onSelectKitten={onSelectKitten}>{kittens}</List>
-					<Detail name={kittens[kitten]} />
-				</Panels>
-			</div>
-		);
-	}
+	render: ({index, kitten, onNavigate, onSelectKitten, ...rest}) => (
+		<div {...rest}>
+			<Panels index={index} onBack={onNavigate}>
+				<List onSelectKitten={onSelectKitten}>{kittens}</List>
+				<Detail name={kittens[kitten]} />
+			</Panels>
+		</div>
+	)
 });
 
 const App = Changeable({prop: 'index', change: 'onNavigate'},

--- a/sandstone/tutorial-kitten-browser/src/App/App.js
+++ b/sandstone/tutorial-kitten-browser/src/App/App.js
@@ -16,7 +16,7 @@ const kittens = [
 	'Kitty'
 ];
 
-const AppBase = kind({
+const _AppBase = kind({
 	name: 'App',
 
 	propTypes: {
@@ -58,11 +58,13 @@ const AppBase = kind({
 	)
 });
 
-const App = Changeable({prop: 'index', change: 'onNavigate'},
+const AppBase = Changeable({prop: 'index', change: 'onNavigate'},
 	Changeable({prop: 'kitten', change: 'onSelectKitten'},
-		ThemeDecorator(AppBase)
+		_AppBase
 	)
 );
+
+const App = ThemeDecorator(AppBase);
 
 export default App;
 export {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Fixed all-samples not to lose focus when navigating to each sample through all-samples menu

### Resolution
Export AppBase which did not apply ThemeDecorator from each sample.
Fixed all-samples to apply ThemeDecorator once.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRN-3524

### Comments