### PR TITLE
WRN-8297: Fixed agate, moonstone samples spotlight issue when navigating to each sample through all-samples menu

### DIFF
--- a/agate/all-samples/src/App/App.js
+++ b/agate/all-samples/src/App/App.js
@@ -1,14 +1,24 @@
-import kind from '@enact/core/kind';
-import ThemeDecorator from '@enact/agate/ThemeDecorator';
-import PropTypes from 'prop-types';
-import {routes} from  '../index';
-import SampleItem from '../components/SampleItem';
 import Scroller from '@enact/agate/Scroller';
+import ThemeDecorator from '@enact/agate/ThemeDecorator';
+import kind from '@enact/core/kind';
+import PropTypes from 'prop-types';
+import {HashRouter as Router, Route} from 'react-router-dom';
+
+import SampleItem from '../components/SampleItem';
+import ButtonToSamples from '../components/ButtonToSamples';
+import {AppBase as PatternDynamicPanel} from '../../../pattern-dynamic-panel/src/App/App';
+import {AppBase as PatternLayout} from '../../../pattern-layout/src/App/App';
+import {appElementBase as PatternLocaleSwitching} from '../../../pattern-locale-switching/src/main';
+import {AppBase as PatternSinglePanel} from '../../../pattern-single-panel/src/App/App';
+import {appElementBase as PatternSinglePanelRedux} from '../../../pattern-single-panel-redux/src/main';
+import {appElementBase as PatternVirtualgridlistApi} from '../../../pattern-virtualgridlist-api/src/main';
+import {appElementBase as PatternVirtuallistPreservingFocus} from '../../../pattern-virtuallist-preserving-focus/src/main';
+
 
 import css from './App.module.less';
 
-const App = kind({
-	name: 'App',
+const NavigationMenu = kind({
+	name: 'NavigationMenu',
 
 	propTypes: {
 		history: PropTypes.object,
@@ -17,33 +27,60 @@ const App = kind({
 		staticContext: PropTypes.any
 	},
 
-	styles: {
-		css,
-		className: 'app'
-	},
-
 	render: ({history, ...props}) => {
 		delete props.match;
 		delete props.location;
 		delete props.staticContext;
 
 		return (
-			<div {...props}>
+			<div {...props} style={{height: '90%'}}>
 				<Scroller>
-					{routes.map(({path}, index) => {
-						if (path !== '/') {
-							return (
-								<SampleItem key={index} path={path} history={history}>
-									{path.substr(1)}
-								</SampleItem>
-							);
-						}
-						return null;
-					})}
+					{
+						// eslint-disable-next-line no-use-before-define
+						routes.map(({path}, index) => {
+							if (path !== '/') {
+								return (
+									<SampleItem key={index} path={path} history={history}>
+										{path.substr(1)}
+									</SampleItem>
+								);
+							}
+							return null;
+						})
+					}
 				</Scroller>
 			</div>
 		);
 	}
+});
+
+const routes = [
+	{path: '/', exact: true, component: NavigationMenu},
+	{path: '/PatternDynamicPanel', component: PatternDynamicPanel},
+	{path: '/PatternLayout', component: PatternLayout},
+	{path: '/PatternLocaleSwitching', component: PatternLocaleSwitching},
+	{path: '/PatternSinglePanel', component: PatternSinglePanel},
+	{path: '/PatternSinglePanelRedux', component: PatternSinglePanelRedux},
+	{path: '/PatternVirtualgridlistApi', component: PatternVirtualgridlistApi},
+	{path: '/PatternVirtuallistPreservingFocus', component: PatternVirtuallistPreservingFocus}
+];
+
+const App = kind({
+	name: 'App',
+
+	styles: {
+		css,
+		className: 'app'
+	},
+
+	render: (props) => (
+		<Router>
+			<div {...props}>
+				<ButtonToSamples />
+				{routes.map((route, index) => <Route key={index} {...route} />)}
+			</div>
+		</Router>
+	)
 });
 
 export default ThemeDecorator(App);

--- a/agate/all-samples/src/index.js
+++ b/agate/all-samples/src/index.js
@@ -1,28 +1,7 @@
 import 'web-animations-js';
-import {HashRouter as Router, Route} from 'react-router-dom';
 import {render} from 'react-dom';
 
-import PatternDynamicPanel from '../../pattern-dynamic-panel/src/App/App';
-import PatternLayout from '../../pattern-layout/src/App/App';
-import PatternLocaleSwitching from '../../pattern-locale-switching/src/main';
-import PatternSinglePanel from '../../pattern-single-panel/src/App/App';
-import PatternSinglePanelRedux from '../../pattern-single-panel-redux/src/main';
-import PatternVirtualgridlistApi from '../../pattern-virtualgridlist-api/src/main';
-import PatternVirtuallistPreservingFocus from '../../pattern-virtuallist-preserving-focus/src/main';
-
 import App from './App';
-import ButtonToSamples from './components/ButtonToSamples';
-
-export const routes = [
-	{path: '/', exact: true, component: App},
-	{path: '/PatternDynamicPanel', component: PatternDynamicPanel},
-	{path: '/PatternLayout', component: PatternLayout},
-	{path: '/PatternLocaleSwitching', component: PatternLocaleSwitching},
-	{path: '/PatternSinglePanel', component: PatternSinglePanel},
-	{path: '/PatternSinglePanelRedux', component: PatternSinglePanelRedux},
-	{path: '/PatternVirtualgridlistApi', component: PatternVirtualgridlistApi},
-	{path: '/PatternVirtuallistPreservingFocus', component: PatternVirtuallistPreservingFocus}
-];
 
 // Router causes an error with our samples, but we don't want our samples to know about router.
 // To avoid this for now we're just surpressing the error.
@@ -34,14 +13,7 @@ console.error = (...args) => {
 };
 /* eslint-enable no-console */
 
-const appElement = (
-	<Router>
-		<div>
-			<ButtonToSamples />
-			{routes.map((route, index) => <Route key={index} {...route} />)}
-		</div>
-	</Router>
-);
+const appElement = (<App />);
 
 // In a browser environment, render the app to the document.
 if (typeof window !== 'undefined') {

--- a/agate/pattern-dynamic-panel/src/App/App.js
+++ b/agate/pattern-dynamic-panel/src/App/App.js
@@ -12,7 +12,7 @@ const Browser = Changeable(
 	FileBrowser
 );
 
-const App = kind({
+const AppBase = kind({
 	name: 'App',
 
 	styles: {
@@ -27,4 +27,7 @@ const App = kind({
 	)
 });
 
-export default ThemeDecorator(App);
+const App = ThemeDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/agate/pattern-layout/src/App/App.js
+++ b/agate/pattern-layout/src/App/App.js
@@ -5,7 +5,6 @@ import {adaptEvent, forward, handle} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
-import compose from 'ramda/src/compose';
 import {Component} from 'react';
 
 import {importAll} from '../components/util';
@@ -32,7 +31,7 @@ itemPusher('Details View', 'Show off details about an item', Details, thumbs['de
 
 const Placeholder = kind({name: 'Placeholder'});
 
-const App = kind({
+const Sample = kind({
 	name: 'LayoutApp',
 
 	propTypes: {
@@ -138,7 +137,8 @@ const AppDecorator = hoc((config, Wrapped) => {
 	};
 });
 
-export default compose(
-	ThemeDecorator,
-	AppDecorator
-)(App);
+const AppBase = AppDecorator(Sample);
+const App = ThemeDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/agate/pattern-locale-switching/src/App/App.js
+++ b/agate/pattern-locale-switching/src/App/App.js
@@ -7,7 +7,7 @@ import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
 
-const App = kind({
+const Sample = kind({
 	name: 'App',
 
 	styles: {
@@ -28,4 +28,8 @@ const App = kind({
 
 const mapStateToProps = ({locale}) => ({locale});
 
-export default connect(mapStateToProps, {})(ThemeDecorator(App));
+const AppBase = connect(mapStateToProps, {})(Sample);
+const App = connect(mapStateToProps, {})(ThemeDecorator(Sample));
+
+export default App;
+export {App, AppBase};

--- a/agate/pattern-locale-switching/src/App/App.js
+++ b/agate/pattern-locale-switching/src/App/App.js
@@ -1,6 +1,7 @@
 import {Panels} from '@enact/agate/Panels';
 import ThemeDecorator from '@enact/agate/ThemeDecorator';
 import kind from '@enact/core/kind';
+import I18nDecorator from '@enact/i18n/I18nDecorator';
 import {connect} from 'react-redux';
 
 import MainPanel from '../views/MainPanel';
@@ -28,7 +29,7 @@ const Sample = kind({
 
 const mapStateToProps = ({locale}) => ({locale});
 
-const AppBase = connect(mapStateToProps, {})(Sample);
+const AppBase = connect(mapStateToProps, {})(I18nDecorator(Sample));
 const App = connect(mapStateToProps, {})(ThemeDecorator(Sample));
 
 export default App;

--- a/agate/pattern-locale-switching/src/main.js
+++ b/agate/pattern-locale-switching/src/main.js
@@ -1,10 +1,16 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
 const store = configureStore();
+
+let appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
 
 let appElement = () => (
 	<Provider store={store}>
@@ -13,3 +19,4 @@ let appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/agate/pattern-single-panel-redux/src/App/App.js
+++ b/agate/pattern-single-panel-redux/src/App/App.js
@@ -6,7 +6,7 @@ import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
 
-const App = kind({
+const AppBase = kind({
 	name: 'App',
 
 	styles: {
@@ -21,4 +21,7 @@ const App = kind({
 	)
 });
 
-export default ThemeDecorator(App);
+const App = ThemeDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/agate/pattern-single-panel-redux/src/main.js
+++ b/agate/pattern-single-panel-redux/src/main.js
@@ -1,10 +1,16 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
 const store = configureStore();
+
+let appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
 
 let appElement = () => (
 	<Provider store={store}>
@@ -13,3 +19,4 @@ let appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/agate/pattern-single-panel/src/App/App.js
+++ b/agate/pattern-single-panel/src/App/App.js
@@ -6,7 +6,7 @@ import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
 
-const App = kind({
+const AppBase = kind({
 	name: 'App',
 
 	styles: {
@@ -21,4 +21,7 @@ const App = kind({
 	)
 });
 
-export default ThemeDecorator(App);
+const App = ThemeDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/agate/pattern-virtualgridlist-api/src/App/App.js
+++ b/agate/pattern-virtualgridlist-api/src/App/App.js
@@ -5,7 +5,7 @@ import MainView from '../views/MainView';
 
 import css from './App.module.less';
 
-const App = kind({
+const AppBase = kind({
 	name: 'App',
 
 	styles: {
@@ -20,4 +20,7 @@ const App = kind({
 	)
 });
 
-export default ThemeDecorator({noAutoFocus: true}, App);
+const App = ThemeDecorator({noAutoFocus: true}, AppBase);
+
+export default App;
+export {App, AppBase};

--- a/agate/pattern-virtualgridlist-api/src/App/App.module.less
+++ b/agate/pattern-virtualgridlist-api/src/App/App.module.less
@@ -1,4 +1,8 @@
+@import '~@enact/ui/styles/mixins.less';
+
 .app {
+  position: absolute;
+  .position(0);
   padding: 0.5rem;
   box-sizing: border-box;
 }

--- a/agate/pattern-virtualgridlist-api/src/main.js
+++ b/agate/pattern-virtualgridlist-api/src/main.js
@@ -1,10 +1,16 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
 const store = configureStore();
+
+let appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
 
 let appElement = () => (
 	<Provider store={store}>
@@ -13,3 +19,4 @@ let appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/agate/pattern-virtuallist-preserving-focus/src/App/App.js
+++ b/agate/pattern-virtuallist-preserving-focus/src/App/App.js
@@ -7,7 +7,7 @@ import {connect} from 'react-redux';
 import {decreaseIndex, increaseIndex} from '../actions';
 import MainPanel from '../views/MainPanel';
 
-const App = kind({
+const Sample = kind({
 	name: 'App',
 
 	propTypes: {
@@ -43,4 +43,8 @@ const mapDispatchToProps = (dispatch) => {
 	};
 };
 
-export default ThemeDecorator(connect(mapStateToProps, mapDispatchToProps)(App));
+const AppBase = connect(mapStateToProps, mapDispatchToProps)(Sample);
+const App = ThemeDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/agate/pattern-virtuallist-preserving-focus/src/main.js
+++ b/agate/pattern-virtuallist-preserving-focus/src/main.js
@@ -1,10 +1,16 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
 const store = configureStore();
+
+const appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
 
 const appElement = () => (
 	<Provider store={store}>
@@ -13,3 +19,4 @@ const appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/moonstone/all-samples/src/App/App.js
+++ b/moonstone/all-samples/src/App/App.js
@@ -24,7 +24,7 @@ import {appElementBase as PatternVirtuallistPreservingFocus} from '../../../patt
 import css from './App.module.less';
 
 const NavigationMenu = kind({
-	name: 'App',
+	name: 'NavigationMenu',
 
 	propTypes: {
 		history: PropTypes.object,

--- a/moonstone/all-samples/src/App/App.js
+++ b/moonstone/all-samples/src/App/App.js
@@ -1,13 +1,29 @@
 import kind from '@enact/core/kind';
 import MoonstoneDecorator from '@enact/moonstone/MoonstoneDecorator';
-import PropTypes from 'prop-types';
-import {routes} from  '../index';
-import SampleItem from '../components/SampleItem';
 import Scroller from '@enact/moonstone/Scroller';
+import PropTypes from 'prop-types';
+import {HashRouter as Router, Route} from 'react-router-dom';
+
+import SampleItem from '../components/SampleItem';
+import ButtonToSamples from '../components/ButtonToSamples';
+import {AppBase as PatternActivityPanels} from '../../../pattern-activity-panels/src/App/App';
+import {appElementBase as PatternActivityPanelsDeepLinking} from '../../../pattern-activity-panels-deep-linking/src/main';
+import {appElementBase as PatternActivityPanelsRedux} from '../../../pattern-activity-panels-redux/src/main';
+import {AppBase as PatternDynamicPanel} from '../../../pattern-dynamic-panel/src/App/App';
+import {AppBase as PatternExpandableList} from '../../../pattern-expandablelist-object/src/App/App';
+import {AppBase as PatternLayout} from '../../../pattern-layout/src/App/App';
+import {appElementBase as PatternLocaleSwitching} from '../../../pattern-locale-switching/src/main';
+import {appElementBase as PatternRoutablePanels} from '../../../pattern-routable-panels/src/main';
+import {AppBase as PatternSinglePanel} from '../../../pattern-single-panel/src/App/App';
+import {appElementBase as PatternSinglePanelRedux} from '../../../pattern-single-panel-redux/src/main';
+import {AppBase as PatternVideoPlayer} from '../../../pattern-video-player/src/App/App';
+import {appElementBase as PatternVirtualgridlistApi} from '../../../pattern-virtualgridlist-api/src/main';
+import {appElementBase as PatternVirtuallistPreservingFocus} from '../../../pattern-virtuallist-preserving-focus/src/main';
+
 
 import css from './App.module.less';
 
-const App = kind({
+const NavigationMenu = kind({
 	name: 'App',
 
 	propTypes: {
@@ -17,33 +33,66 @@ const App = kind({
 		staticContext: PropTypes.any
 	},
 
-	styles: {
-		css,
-		className: 'app'
-	},
-
 	render: ({history, ...props}) => {
 		delete props.match;
 		delete props.location;
 		delete props.staticContext;
 
 		return (
-			<div {...props}>
+			<div {...props} style={{height: '90%'}}>
 				<Scroller>
-					{routes.map(({path}, index) => {
-						if (path !== '/') {
-							return (
-								<SampleItem key={index} path={path} history={history}>
-									{path.substr(1)}
-								</SampleItem>
-							);
-						}
-						return null;
-					})}
+					{
+						// eslint-disable-next-line no-use-before-define
+						routes.map(({path}, index) => {
+							if (path !== '/') {
+								return (
+									<SampleItem key={index} path={path} history={history}>
+										{path.substr(1)}
+									</SampleItem>
+								);
+							}
+							return null;
+						})
+					}
 				</Scroller>
 			</div>
 		);
 	}
+});
+
+const routes = [
+	{path: '/', exact: true, component: NavigationMenu},
+	{path: '/PatternActivityPanels', component: PatternActivityPanels},
+	{path: '/PatternActivityPanelsDeepLinking', component: PatternActivityPanelsDeepLinking},
+	{path: '/PatternActivityPanelsRedux', component: PatternActivityPanelsRedux},
+	{path: '/PatternDynamicPanel', component: PatternDynamicPanel},
+	{path: '/PatternExpandableList', component: PatternExpandableList},
+	{path: '/PatternLayout', component: PatternLayout},
+	{path: '/PatternLocaleSwitching', component: PatternLocaleSwitching},
+	{path: '/PatternRoutablePanels', component: PatternRoutablePanels},
+	{path: '/PatternSinglePanel', component: PatternSinglePanel},
+	{path: '/PatternSinglePanelRedux', component: PatternSinglePanelRedux},
+	{path: '/PatternVideoPlayer', component: PatternVideoPlayer},
+	{path: '/PatternVirtualgridlistApi', component: PatternVirtualgridlistApi},
+	{path: '/PatternVirtuallistPreservingFocus', component: PatternVirtuallistPreservingFocus}
+];
+
+const App = kind({
+	name: 'App',
+
+	styles: {
+		css,
+		className: 'app'
+	},
+
+	render: (props) => (
+		<Router>
+			<div {...props}>
+				<ButtonToSamples />
+				{routes.map((route, index) => <Route key={index} {...route} />)}
+			</div>
+		</Router>
+	)
 });
 
 export default MoonstoneDecorator(App);

--- a/moonstone/all-samples/src/index.js
+++ b/moonstone/all-samples/src/index.js
@@ -1,40 +1,7 @@
 import 'web-animations-js';
-import {HashRouter as Router, Route} from 'react-router-dom';
 import {render} from 'react-dom';
 
-import PatternActivityPanels from '../../pattern-activity-panels/src/App/App';
-import PatternActivityPanelsDeepLinking from '../../pattern-activity-panels-deep-linking/src/main';
-import PatternActivityPanelsRedux from '../../pattern-activity-panels-redux/src/main';
-import PatternDynamicPanel from '../../pattern-dynamic-panel/src/App/App';
-import PatternExpandableList from '../../pattern-expandablelist-object/src/App/App';
-import PatternLayout from '../../pattern-layout/src/App/App';
-import PatternLocaleSwitching from '../../pattern-locale-switching/src/main';
-import PatternRoutablePanels from '../../pattern-routable-panels/src/main';
-import PatternSinglePanel from '../../pattern-single-panel/src/App/App';
-import PatternSinglePanelRedux from '../../pattern-single-panel-redux/src/main';
-import PatternVideoPlayer from '../../pattern-video-player/src/App/App';
-import PatternVirtualgridlistApi from '../../pattern-virtualgridlist-api/src/main';
-import PatternVirtuallistPreservingFocus from '../../pattern-virtuallist-preserving-focus/src/main';
-
 import App from './App';
-import ButtonToSamples from './components/ButtonToSamples';
-
-export const routes = [
-	{path: '/', exact: true, component: App},
-	{path: '/PatternActivityPanels', component: PatternActivityPanels},
-	{path: '/PatternActivityPanelsDeepLinking', component: PatternActivityPanelsDeepLinking},
-	{path: '/PatternActivityPanelsRedux', component: PatternActivityPanelsRedux},
-	{path: '/PatternDynamicPanel', component: PatternDynamicPanel},
-	{path: '/PatternExpandableList', component: PatternExpandableList},
-	{path: '/PatternLayout', component: PatternLayout},
-	{path: '/PatternLocaleSwitching', component: PatternLocaleSwitching},
-	{path: '/PatternRoutablePanels', component: PatternRoutablePanels},
-	{path: '/PatternSinglePanel', component: PatternSinglePanel},
-	{path: '/PatternSinglePanelRedux', component: PatternSinglePanelRedux},
-	{path: '/PatternVideoPlayer', component: PatternVideoPlayer},
-	{path: '/PatternVirtualgridlistApi', component: PatternVirtualgridlistApi},
-	{path: '/PatternVirtuallistPreservingFocus', component: PatternVirtuallistPreservingFocus}
-];
 
 // Router causes an error with our samples, but we don't want our samples to know about router.
 // To avoid this for now we're just surpressing the error.
@@ -46,14 +13,7 @@ console.error = (...args) => {
 };
 /* eslint-enable no-console */
 
-const appElement = (
-	<Router>
-		<div>
-			<ButtonToSamples />
-			{routes.map((route, index) => <Route key={index} {...route} />)}
-		</div>
-	</Router>
-);
+const appElement = (<App />);
 
 // In a browser environment, render the app to the document.
 if (typeof window !== 'undefined') {

--- a/moonstone/pattern-activity-panels-deep-linking/src/App/App.js
+++ b/moonstone/pattern-activity-panels-deep-linking/src/App/App.js
@@ -9,7 +9,7 @@ import AppStateDecorator from './AppStateDecorator';
 
 const RoutablePanels = Routable({navigate: 'onSelectBreadcrumb'}, ActivityPanels);
 
-const App = kind({
+const Sample = kind({
 	name: 'App',
 
 	propTypes: {
@@ -38,8 +38,8 @@ const App = kind({
 	}
 });
 
-export default MoonstoneDecorator(
-	AppStateDecorator(
-		App
-	)
-);
+const AppBase = AppStateDecorator(Sample);
+const App = MoonstoneDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/moonstone/pattern-activity-panels-deep-linking/src/main.js
+++ b/moonstone/pattern-activity-panels-deep-linking/src/main.js
@@ -1,6 +1,6 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
@@ -9,6 +9,12 @@ const store = configureStore({
 	path: launchParam
 });
 
+let appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
+
 let appElement = () => (
 	<Provider store={store}>
 		<App />
@@ -16,3 +22,4 @@ let appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/moonstone/pattern-activity-panels-redux/src/App/App.js
+++ b/moonstone/pattern-activity-panels-redux/src/App/App.js
@@ -7,7 +7,7 @@ import {connect} from 'react-redux';
 import {decreaseIndex, increaseIndex} from '../actions';
 import MainPanel from '../views/MainPanel';
 
-const App = kind({
+const Sample = kind({
 	name: 'App',
 
 	propTypes: {
@@ -43,4 +43,8 @@ const mapDispatchToProps = (dispatch) => {
 	};
 };
 
-export default MoonstoneDecorator(connect(mapStateToProps, mapDispatchToProps)(App));
+const AppBase = connect(mapStateToProps, mapDispatchToProps)(Sample);
+const App = MoonstoneDecorator(connect(mapStateToProps, mapDispatchToProps)(Sample));
+
+export default App;
+export {App, AppBase};

--- a/moonstone/pattern-activity-panels-redux/src/main.js
+++ b/moonstone/pattern-activity-panels-redux/src/main.js
@@ -1,10 +1,16 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
 const store = configureStore();
+
+let appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
 
 let appElement = () => (
 	<Provider store={store}>
@@ -13,3 +19,4 @@ let appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/moonstone/pattern-activity-panels/src/App/App.js
+++ b/moonstone/pattern-activity-panels/src/App/App.js
@@ -6,7 +6,7 @@ import ButtonPanel from '../views/ButtonPanel';
 import ItemPanel from '../views/ItemPanel';
 import MainPanel from '../views/MainPanel';
 
-class App extends Component {
+class AppBase extends Component {
 	constructor (props) {
 		super(props);
 		this.state = {
@@ -30,4 +30,7 @@ class App extends Component {
 	}
 }
 
-export default MoonstoneDecorator(App);
+const App = MoonstoneDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/moonstone/pattern-dynamic-panel/src/App/App.js
+++ b/moonstone/pattern-dynamic-panel/src/App/App.js
@@ -12,7 +12,7 @@ const Browser = Changeable(
 	FileBrowser
 );
 
-const App = kind({
+const AppBase = kind({
 	name: 'App',
 
 	styles: {
@@ -27,4 +27,7 @@ const App = kind({
 	)
 });
 
-export default MoonstoneDecorator(App);
+const App = MoonstoneDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/moonstone/pattern-dynamic-panel/src/components/FileBrowser/FileBrowser.js
+++ b/moonstone/pattern-dynamic-panel/src/components/FileBrowser/FileBrowser.js
@@ -15,6 +15,8 @@ import rainbow from '../../../assets/images/rainbow.jpg';
 
 import DynamicPanel from '../DynamicPanel';
 
+import css from './FileBrowser.module.less';
+
 const a = {
 	files: [
 		{name: 'b', directory: true},
@@ -98,11 +100,12 @@ const FileBrowserBase = kind({
 				<Image src={filePhotos[leaf.replace('.jpg', '')]} />;
 
 			return (
-				<DynamicPanel {...rest} path={path}>
-					{component}
-				</DynamicPanel>
+				<div className={css.fileBrowser}>
+					<DynamicPanel {...rest} path={path}>
+						{component}
+					</DynamicPanel>
+				</div>
 			);
-
 		}
 	},
 

--- a/moonstone/pattern-dynamic-panel/src/components/FileBrowser/FileBrowser.module.less
+++ b/moonstone/pattern-dynamic-panel/src/components/FileBrowser/FileBrowser.module.less
@@ -1,0 +1,6 @@
+@import '~@enact/ui/styles/mixins.less';
+
+.fileBrowser {
+    position: absolute;
+    .position(0);
+}

--- a/moonstone/pattern-expandablelist-object/src/App/App.js
+++ b/moonstone/pattern-expandablelist-object/src/App/App.js
@@ -4,7 +4,7 @@ import {Panels} from '@enact/moonstone/Panels';
 
 import MainPanel from '../views/MainPanel';
 
-const App = kind({
+const AppBase = kind({
 	name: 'App',
 
 	render: (props) => (
@@ -16,4 +16,7 @@ const App = kind({
 	)
 });
 
-export default MoonstoneDecorator(App);
+const App = MoonstoneDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/moonstone/pattern-layout/src/App/App.js
+++ b/moonstone/pattern-layout/src/App/App.js
@@ -5,7 +5,6 @@ import Button from '@enact/moonstone/Button';
 import MoonstoneDecorator from '@enact/moonstone/MoonstoneDecorator';
 import {ActivityPanels} from '@enact/moonstone/Panels';
 import PropTypes from 'prop-types';
-import compose from 'ramda/src/compose';
 import {Component} from 'react';
 
 import {importAll} from '../components/util';
@@ -32,7 +31,7 @@ itemPusher('Details View', 'Show off details about an item', Details, thumbs['de
 
 const Placeholder = kind({name: 'Placeholder'});
 
-const App = kind({
+const Sample = kind({
 	name: 'LayoutApp',
 
 	propTypes: {
@@ -138,7 +137,8 @@ const AppDecorator = hoc((config, Wrapped) => {
 	};
 });
 
-export default compose(
-	MoonstoneDecorator,
-	AppDecorator
-)(App);
+const AppBase = AppDecorator(Sample);
+const App = MoonstoneDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/moonstone/pattern-locale-switching/src/App/App.js
+++ b/moonstone/pattern-locale-switching/src/App/App.js
@@ -7,7 +7,7 @@ import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
 
-const App = kind({
+const Sample = kind({
 	name: 'App',
 
 	styles: {
@@ -28,4 +28,8 @@ const App = kind({
 
 const mapStateToProps = ({locale}) => ({locale});
 
-export default connect(mapStateToProps, {})(MoonstoneDecorator(App));
+const AppBase = connect(mapStateToProps, {})(Sample);
+const App = connect(mapStateToProps, {})(MoonstoneDecorator(Sample));
+
+export default App;
+export {App, AppBase};

--- a/moonstone/pattern-locale-switching/src/App/App.js
+++ b/moonstone/pattern-locale-switching/src/App/App.js
@@ -1,4 +1,5 @@
 import kind from '@enact/core/kind';
+import I18nDecorator from '@enact/i18n/I18nDecorator';
 import MoonstoneDecorator from '@enact/moonstone/MoonstoneDecorator';
 import {Panels} from '@enact/moonstone/Panels';
 import {connect} from 'react-redux';
@@ -28,7 +29,7 @@ const Sample = kind({
 
 const mapStateToProps = ({locale}) => ({locale});
 
-const AppBase = connect(mapStateToProps, {})(Sample);
+const AppBase = connect(mapStateToProps, {})(I18nDecorator(Sample));
 const App = connect(mapStateToProps, {})(MoonstoneDecorator(Sample));
 
 export default App;

--- a/moonstone/pattern-locale-switching/src/main.js
+++ b/moonstone/pattern-locale-switching/src/main.js
@@ -1,10 +1,16 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
 const store = configureStore();
+
+let appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
 
 let appElement = () => (
 	<Provider store={store}>
@@ -13,3 +19,4 @@ let appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/moonstone/pattern-routable-panels/src/App/App.js
+++ b/moonstone/pattern-routable-panels/src/App/App.js
@@ -11,7 +11,7 @@ import AppStateDecorator from './AppStateDecorator';
 
 const RoutablePanels = Routable({navigate: 'onBack'}, Panels);
 
-const App = kind({
+const Sample = kind({
 	name: 'App',
 
 	propTypes: {
@@ -40,8 +40,8 @@ const App = kind({
 	}
 });
 
-export default MoonstoneDecorator(
-	AppStateDecorator(
-		App
-	)
-);
+const AppBase = AppStateDecorator(Sample);
+const App = MoonstoneDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/moonstone/pattern-routable-panels/src/main.js
+++ b/moonstone/pattern-routable-panels/src/main.js
@@ -1,10 +1,16 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
 const store = configureStore();
+
+let appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
 
 let appElement = () => (
 	<Provider store={store}>
@@ -13,3 +19,4 @@ let appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/moonstone/pattern-single-panel-redux/src/App/App.js
+++ b/moonstone/pattern-single-panel-redux/src/App/App.js
@@ -6,7 +6,7 @@ import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
 
-const App = kind({
+const AppBase = kind({
 	name: 'App',
 
 	styles: {
@@ -21,4 +21,7 @@ const App = kind({
 	)
 });
 
-export default MoonstoneDecorator(App);
+const App = MoonstoneDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/moonstone/pattern-single-panel-redux/src/main.js
+++ b/moonstone/pattern-single-panel-redux/src/main.js
@@ -1,10 +1,16 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
 const store = configureStore();
+
+let appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
 
 let appElement = () => (
 	<Provider store={store}>
@@ -13,3 +19,4 @@ let appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/moonstone/pattern-single-panel/src/App/App.js
+++ b/moonstone/pattern-single-panel/src/App/App.js
@@ -6,7 +6,7 @@ import MainPanel from '../views/MainPanel';
 
 import css from './App.module.less';
 
-const App = kind({
+const AppBase = kind({
 	name: 'App',
 
 	styles: {
@@ -21,4 +21,7 @@ const App = kind({
 	)
 });
 
-export default MoonstoneDecorator(App);
+const App = MoonstoneDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/moonstone/pattern-video-player/src/App/App.js
+++ b/moonstone/pattern-video-player/src/App/App.js
@@ -15,7 +15,7 @@ import css from './App.module.less';
 
 const getVideo = (index) => videos[index];
 
-class App extends Component {
+class AppBase extends Component {
 	static propTypes = {
 		/**
 		 * Assign an alternate panel index to start on.
@@ -120,4 +120,7 @@ class App extends Component {
 	}
 }
 
-export default MoonstoneDecorator(App);
+const App = MoonstoneDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/moonstone/pattern-virtualgridlist-api/src/App/App.js
+++ b/moonstone/pattern-virtualgridlist-api/src/App/App.js
@@ -5,7 +5,7 @@ import MainView from '../views/MainView';
 
 import css from './App.module.less';
 
-const App = kind({
+const AppBase = kind({
 	name: 'App',
 
 	styles: {
@@ -20,4 +20,7 @@ const App = kind({
 	)
 });
 
-export default MoonstoneDecorator({noAutoFocus: true}, App);
+const App = MoonstoneDecorator({noAutoFocus: true}, AppBase);
+
+export default App;
+export {App, AppBase};

--- a/moonstone/pattern-virtualgridlist-api/src/App/App.module.less
+++ b/moonstone/pattern-virtualgridlist-api/src/App/App.module.less
@@ -1,4 +1,8 @@
+@import '~@enact/ui/styles/mixins.less';
+
 .app {
+  position: absolute;
+  .position(0);
   padding: 0.5rem;
   box-sizing: border-box;
 }

--- a/moonstone/pattern-virtualgridlist-api/src/main.js
+++ b/moonstone/pattern-virtualgridlist-api/src/main.js
@@ -1,10 +1,16 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
 const store = configureStore();
+
+const appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
 
 let appElement = () => (
 	<Provider store={store}>
@@ -13,3 +19,4 @@ let appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/moonstone/pattern-virtuallist-preserving-focus/src/App/App.js
+++ b/moonstone/pattern-virtuallist-preserving-focus/src/App/App.js
@@ -7,7 +7,7 @@ import {connect} from 'react-redux';
 import {decreaseIndex, increaseIndex} from '../actions';
 import MainPanel from '../views/MainPanel';
 
-const App = kind({
+const Sample = kind({
 	name: 'App',
 
 	propTypes: {
@@ -43,4 +43,8 @@ const mapDispatchToProps = (dispatch) => {
 	};
 };
 
-export default MoonstoneDecorator(connect(mapStateToProps, mapDispatchToProps)(App));
+const AppBase = connect(mapStateToProps, mapDispatchToProps)(Sample);
+const App = MoonstoneDecorator(AppBase);
+
+export default App;
+export {App, AppBase};

--- a/moonstone/pattern-virtuallist-preserving-focus/src/main.js
+++ b/moonstone/pattern-virtuallist-preserving-focus/src/main.js
@@ -1,10 +1,16 @@
 import {Provider} from 'react-redux';
 
-import App from './App';
+import App, {AppBase} from './App';
 import configureStore from './store';
 
 // set default launch path
 const store = configureStore();
+
+const appElementBase = () => (
+	<Provider store={store}>
+		<AppBase />
+	</Provider>
+);
 
 const appElement = () => (
 	<Provider store={store}>
@@ -13,3 +19,4 @@ const appElement = () => (
 );
 
 export default appElement;
+export {appElement, appElementBase};

--- a/sandstone/all-samples/src/App/App.js
+++ b/sandstone/all-samples/src/App/App.js
@@ -21,7 +21,7 @@ import {AppBase as TutorialKittenBrowser} from '../../../tutorial-kitten-browser
 import css from './App.module.less';
 
 const NavigationMenu = kind({
-	name: 'App',
+	name: 'NavigationMenu',
 
 	propTypes: {
 		history: PropTypes.object,

--- a/sandstone/pattern-locale-switching/src/App/App.js
+++ b/sandstone/pattern-locale-switching/src/App/App.js
@@ -1,4 +1,5 @@
 import kind from '@enact/core/kind';
+import I18nDecorator from '@enact/i18n/I18nDecorator';
 import {Panels} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
 import {connect} from 'react-redux';
@@ -28,7 +29,7 @@ const Sample = kind({
 
 const mapStateToProps = ({locale}) => ({locale});
 
-const AppBase = connect(mapStateToProps, {})(Sample);
+const AppBase = connect(mapStateToProps, {})(I18nDecorator(Sample));
 const App = connect(mapStateToProps, {})(ThemeDecorator(Sample));
 
 export default App;

--- a/sandstone/pattern-virtualgridlist-api/src/App/App.module.less
+++ b/sandstone/pattern-virtualgridlist-api/src/App/App.module.less
@@ -1,9 +1,8 @@
+@import '~@enact/ui/styles/mixins.less';
+
 .app {
+	position: absolute;
+	.position(0);
 	padding: 0.5rem;
 	box-sizing: border-box;
-	position: absolute;
-	top: 0;
-	left: 0;
-	bottom: 0;
-	right: 0;
 }


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Fixed agate, moonstone all-samples not to lose focus when navigating to each sample through all-samples menu

### Resolution
- Export AppBase without applying ThemeDecorator from each sample.
- Fixed all-samples to apply ThemeDecorator once.
- Fixed locale-switching with redux
  - In pattern-locale-switching, changing locale with redux was not working because we removed `ThemeDecorator` from the component passed to connect(). 
(sandstone/pattern-locale-switching/src/App/App.js, line 46) `const AppBase = connect(mapStateToProps, {})(Sample);`
  - locale-switching with redux did not work because `locale` props could not be passed to `ThemeDecorator`. Instead of passing it to themeDecorator, we passed `locale` props to `I18nDecorator` to enable locale-switching with redux. 
- Remove scroller in moonstone/pattern-dynamic-panel

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRN-8297

### Comments