### PR TITLE
WRN-12939: Handle skin names with spaces.

### DIFF
--- a/sandstone/custom-skin/src/components/OutputField/OutputField.js
+++ b/sandstone/custom-skin/src/components/OutputField/OutputField.js
@@ -42,7 +42,7 @@ const OutputField = kind({
 				</pre>
 				<TooltipButton className={css.copyBtn} icon="files" onClick={copyToClipboard} size="small" tooltipText="Copy to clipboard">Copy</TooltipButton>
 				<TooltipButton className={css.copyBtn} icon="download" onClick={generateFile} size="small" tooltipText="Get CSS file">Download Skin</TooltipButton>
-				<TooltipButton className={css.copyBtn} onClick={setDefaultState} size="small" tooltipText="Restore skin to default colors">Back to Default</TooltipButton>
+				<TooltipButton className={css.copyBtn} icon="refresh" onClick={setDefaultState} size="small" tooltipText="Restore skin to default colors">Back to Default</TooltipButton>
 			</div>
 		);
 	}});

--- a/sandstone/custom-skin/src/custom_skin.css
+++ b/sandstone/custom-skin/src/custom_skin.css
@@ -1,5 +1,5 @@
 .sandstone-theme {
-	/* Skin Name:  */
+	/* Skin Name:  ;/* */
 	--sand-text-color: #FB9039; /* Normal Text Color */
 	--sand-text-sub-color: #FBA44D; /* Subtitle Text Color */
 	--sand-focus-text-color-rgb: 251, 184, 97; /* Focused Text Color (Must be RGB comma separated format) */

--- a/sandstone/custom-skin/src/utils.js
+++ b/sandstone/custom-skin/src/utils.js
@@ -44,7 +44,7 @@ const generateCSS = (colors) => {
 		const OverlayPanelBg = convertHexToRGB(colors[1]);
 
 		return '.sandstone-theme {\n' +
-			`	/* Skin Name: ${colors[0]}; The name of the skin */\n` +
+			`	/* Skin Name: ${colors[0] ? colors[0] : 'Untitled'}; /* The name of the skin */\n` +
 			`	--sand-text-color: ${colors[2].toUpperCase()}; /* Normal Text Color */\n` +
 			`	--sand-text-sub-color: ${colors[3]?.toUpperCase()}; /* Subtitle Text Color */\n` +
 			`	--sand-focus-text-color-rgb: ${FocusedText[0]}, ${FocusedText[1]}, ${FocusedText[2]};` +

--- a/sandstone/custom-skin/src/utils.js
+++ b/sandstone/custom-skin/src/utils.js
@@ -44,7 +44,7 @@ const generateCSS = (colors) => {
 		const OverlayPanelBg = convertHexToRGB(colors[1]);
 
 		return '.sandstone-theme {\n' +
-			`	/* Skin Name: ${colors[0]} */\n` +
+			`	/* Skin Name: ${colors[0]}; The name of the skin */\n` +
 			`	--sand-text-color: ${colors[2].toUpperCase()}; /* Normal Text Color */\n` +
 			`	--sand-text-sub-color: ${colors[3]?.toUpperCase()}; /* Subtitle Text Color */\n` +
 			`	--sand-focus-text-color-rgb: ${FocusedText[0]}, ${FocusedText[1]}, ${FocusedText[2]};` +
@@ -193,7 +193,7 @@ const hexColors = (color1, color2) => {
 const getColorsFromString = (colors) => {
 	try {
 		let colorSets = colors.map(color => color.split(':'));
-		colorSets = colorSets.map(colorSet => [colorSet[0], colorSet[1].split(';')[0].replace(/ /g, '')]);
+		colorSets = colorSets.map(colorSet => [colorSet[0], colorSet[1].split(';')[0].slice(1)]);
 		colorSets[0][1] = colorSets[0][1].split('*/')[0];
 
 		return colorSets;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Alexandru Morariu (alexandru.morariu@lgepartner.com)

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Made it so the skin name retains the spaces in the name when importing a skin, so the given name will be the same as initially set.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-12939

### Comments
