### PR TITLE
WRO-3893: Fixed React 18 Suspense sample content is not loading inside all-samples app

### DIFF
--- a/sandstone/pattern-react18-new/src/App/App.js
+++ b/sandstone/pattern-react18-new/src/App/App.js
@@ -14,13 +14,13 @@ const App = (props) => {
 		<div {...props} className={classnames(props.className, css.app)}>
 			<Header noCloseButton title="React 18 Features" type="mini" />
 			<TabLayout orientation="horizontal" className={css.tabLayout}>
-				<Tab className={css.tab} title="Automatic Batching">
+				<Tab title="Automatic Batching">
 					<Batching />
 				</Tab>
-				<Tab className={css.tab} title="Suspense">
+				<Tab title="Suspense">
 					<Suspense />
 				</Tab>
-				<Tab className={css.tab} title="useTransition">
+				<Tab title="useTransition">
 					<UseTransition />
 				</Tab>
 			</TabLayout>

--- a/sandstone/pattern-react18-new/src/views/Suspense/NoSuspense.js
+++ b/sandstone/pattern-react18-new/src/views/Suspense/NoSuspense.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 
 import SamplePage from './SamplePage';
 
@@ -13,12 +13,12 @@ const NoSuspense = () => {
 		<div>
 			{
 				loading ? null :
-					<div>
-						<SamplePage/>
-					</div>
+				<div>
+					<SamplePage/>
+				</div>
 			}
 		</div>
-	)
-}
+	);
+};
 
 export default NoSuspense;

--- a/sandstone/pattern-react18-new/src/views/Suspense/NoSuspense.js
+++ b/sandstone/pattern-react18-new/src/views/Suspense/NoSuspense.js
@@ -12,10 +12,10 @@ const NoSuspense = () => {
 	return (
 		<div>
 			{
-				loading ? null :
-				<div>
-					<SamplePage/>
-				</div>
+				!loading &&
+					<div>
+						<SamplePage />
+					</div>
 			}
 		</div>
 	);

--- a/sandstone/pattern-react18-new/src/views/Suspense/NoSuspense.js
+++ b/sandstone/pattern-react18-new/src/views/Suspense/NoSuspense.js
@@ -1,0 +1,24 @@
+import React, {useEffect, useState} from 'react';
+
+import SamplePage from './SamplePage';
+
+const NoSuspense = () => {
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		setTimeout(() => setLoading(false), 3000);
+	}, []);
+
+	return (
+		<div>
+			{
+				loading ? null :
+					<div>
+						<SamplePage/>
+					</div>
+			}
+		</div>
+	)
+}
+
+export default NoSuspense;

--- a/sandstone/pattern-react18-new/src/views/Suspense/SamplePage.js
+++ b/sandstone/pattern-react18-new/src/views/Suspense/SamplePage.js
@@ -18,7 +18,7 @@ const renderItem = ({index, ...rest}) => {
 	);
 };
 
-for (let i = 0; i < 12; i++) {
+for (let i = 0; i < 6; i++) {
 	const
 		count = ('0' + i).slice(-2),
 		caption = `Item ${count} caption`,

--- a/sandstone/pattern-react18-new/src/views/Suspense/SkeletonPage.js
+++ b/sandstone/pattern-react18-new/src/views/Suspense/SkeletonPage.js
@@ -16,7 +16,7 @@ const renderItem = () => {
 				Loading...
 			</ImageItem>
 			<Spinner
-				style={{position: 'absolute', top: '50%', left: '50%', margin: '-63px 0 0 -39px'}}
+				style={{position: 'absolute', top: '50%', left: '50%', margin: '-20% 0 0 -12%'}}
 				transparent
 			/>
 		</>
@@ -28,7 +28,7 @@ const SkeletonPage = kind({
 
 	render: () => (
 		<VirtualGridList
-			dataSize={12}
+			dataSize={6}
 			itemRenderer={renderItem}
 			itemSize={{
 				minWidth: ri.scale(540),

--- a/sandstone/pattern-react18-new/src/views/Suspense/Suspense.js
+++ b/sandstone/pattern-react18-new/src/views/Suspense/Suspense.js
@@ -1,9 +1,9 @@
-import React, {Suspense, useState} from 'react';
 import Heading from '@enact/sandstone/Heading';
 import TabLayout, {Tab} from '@enact/sandstone/TabLayout';
+import React, {Suspense, useState} from 'react';
 
-import SkeletonPage from './SkeletonPage';
 import NoSuspense from './NoSuspense';
+import SkeletonPage from './SkeletonPage';
 
 // Load the "SamplePage" component after 3s
 const getSamplePage = () => {

--- a/sandstone/pattern-react18-new/src/views/Suspense/Suspense.js
+++ b/sandstone/pattern-react18-new/src/views/Suspense/Suspense.js
@@ -1,13 +1,13 @@
 import Heading from '@enact/sandstone/Heading';
 import TabLayout, {Tab} from '@enact/sandstone/TabLayout';
-import React, {Suspense, useState} from 'react';
+import {lazy, Suspense, useCallback, useState} from 'react';
 
 import NoSuspense from './NoSuspense';
 import SkeletonPage from './SkeletonPage';
 
 // Load the "SamplePage" component after 3s
 const getSamplePage = () => {
-	return React.lazy(() => {
+	return lazy(() => {
 		return new Promise((resolve) => {
 			setTimeout(() => {
 				resolve(import('./SamplePage'));
@@ -19,15 +19,15 @@ const getSamplePage = () => {
 let SamplePage = getSamplePage();
 
 const SuspensePage = () => {
-	const [index, setIndex] = useState(0);
+	const [tabIndex, setTabIndex] = useState(0);
 
-	const lazyReload = ({index}) => {
+	const lazyReload = useCallback(({index}) => {
 		SamplePage = getSamplePage();
-		setIndex(index);
-	};
+		setTabIndex(index);
+	});
 
 	return (
-		<TabLayout index={index} onSelect={lazyReload} orientation="horizontal">
+		<TabLayout index={tabIndex} onSelect={lazyReload} orientation="horizontal">
 			<Tab title="Using Suspense">
 				<Heading>
 					Suspense offers a fallback UI for better user experience.

--- a/sandstone/pattern-react18-new/src/views/Suspense/Suspense.js
+++ b/sandstone/pattern-react18-new/src/views/Suspense/Suspense.js
@@ -24,7 +24,7 @@ const SuspensePage = () => {
 	const lazyReload = useCallback(({index}) => {
 		SamplePage = getSamplePage();
 		setTabIndex(index);
-	});
+	}, []);
 
 	return (
 		<TabLayout index={tabIndex} onSelect={lazyReload} orientation="horizontal">

--- a/sandstone/pattern-react18-new/src/views/Suspense/Suspense.js
+++ b/sandstone/pattern-react18-new/src/views/Suspense/Suspense.js
@@ -4,7 +4,6 @@ import TabLayout, {Tab} from '@enact/sandstone/TabLayout';
 
 import SkeletonPage from './SkeletonPage';
 import NoSuspense from './NoSuspense';
-import css from "../../App/App.module.less";
 
 // Load the "SamplePage" component after 3s
 const getSamplePage = () => {

--- a/sandstone/pattern-react18-new/src/views/Suspense/Suspense.js
+++ b/sandstone/pattern-react18-new/src/views/Suspense/Suspense.js
@@ -1,8 +1,10 @@
-import React, {Suspense, useEffect, useState} from 'react';
-import Button from '@enact/sandstone/Button';
-import {Header, Panel, Panels} from '@enact/sandstone/Panels';
+import React, {Suspense, useState} from 'react';
+import Heading from '@enact/sandstone/Heading';
+import TabLayout, {Tab} from '@enact/sandstone/TabLayout';
 
 import SkeletonPage from './SkeletonPage';
+import NoSuspense from './NoSuspense';
+import css from "../../App/App.module.less";
 
 // Load the "SamplePage" component after 3s
 const getSamplePage = () => {
@@ -20,31 +22,28 @@ let SamplePage = getSamplePage();
 const SuspensePage = () => {
 	const [index, setIndex] = useState(0);
 
-	useEffect( () => {
-		// Lazy reload the "SamplePage" component when index changes
+	const lazyReload = ({index}) => {
 		SamplePage = getSamplePage();
-	}, [index]);
-
-	const nextPanel = () => setIndex(index + 1); /* eslint-disable react/jsx-no-bind */
-	const prevPanel = () => setIndex(index - 1); /* eslint-disable react/jsx-no-bind */
+		setIndex(index);
+	};
 
 	return (
-		<Panels index={index} noCloseButton onBack={prevPanel}>
-			<Panel>
-				<Header subtitle="Suspense offers a fallback UI for better user experience. Check out next panel." type="mini">
-					<slotAfter>
-						<Button size="small" icon="arrowlargeright" onClick={nextPanel} />
-					</slotAfter>
-				</Header>
+		<TabLayout index={index} onSelect={lazyReload} orientation="horizontal">
+			<Tab title="Using Suspense">
+				<Heading>
+					Suspense offers a fallback UI for better user experience.
+				</Heading>
 				<Suspense fallback={<SkeletonPage />}>
 					<SamplePage />
 				</Suspense>
-			</Panel>
-			<Panel>
-				<Header subtitle="Page is empty until all the data is available. Please wait 3s." type="mini" />
-				<SamplePage />
-			</Panel>
-		</Panels>
+			</Tab>
+			<Tab title="NOT Using Suspense">
+				<Heading>
+					Page is empty until all the data is available. Please wait 3s.
+				</Heading>
+				<NoSuspense />
+			</Tab>
+		</TabLayout>
 	);
 };
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Refactored React 18 Suspense sample content to load inside all-samples app. Replaced Panels with TabLayout. Removed unused classNames from React18 sampler file App.js.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-3893

### Comments
