### PR TITLE
WRP-5254: Changed samples "eslintConfig" to use eslint-config-enact-proxy

### DIFF
--- a/agate/all-samples/package.json
+++ b/agate/all-samples/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/agate": "^2.0.3",
@@ -45,5 +45,8 @@
     "react-router-dom": "^6.8.0",
     "redux": "^4.2.1",
     "redux-thunk": "^2.4.2"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/agate/pattern-dynamic-panel/package.json
+++ b/agate/pattern-dynamic-panel/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/agate": "^2.0.3",
@@ -38,5 +38,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/agate/pattern-layout/package.json
+++ b/agate/pattern-layout/package.json
@@ -24,7 +24,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/agate": "^2.0.3",
@@ -38,5 +38,8 @@
     "query-string": "^7.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/agate/pattern-locale-switching/package.json
+++ b/agate/pattern-locale-switching/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/agate": "^2.0.3",
@@ -42,5 +42,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/agate/pattern-single-panel-redux/package.json
+++ b/agate/pattern-single-panel-redux/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/agate": "^2.0.3",
@@ -41,5 +41,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/agate/pattern-single-panel/package.json
+++ b/agate/pattern-single-panel/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/agate": "^2.0.3",
@@ -38,5 +38,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/agate/pattern-virtualgridlist-api/package.json
+++ b/agate/pattern-virtualgridlist-api/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/agate": "^2.0.3",
@@ -41,5 +41,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/agate/pattern-virtuallist-preserving-focus/package.json
+++ b/agate/pattern-virtuallist-preserving-focus/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/agate": "^2.0.3",
@@ -41,5 +41,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/all-samples/package.json
+++ b/moonstone/all-samples/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -45,5 +45,8 @@
     "react-router-dom": "^6.8.0",
     "redux": "^4.2.1",
     "redux-thunk": "^2.4.2"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/pattern-activity-panels-deep-linking/package.json
+++ b/moonstone/pattern-activity-panels-deep-linking/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -41,5 +41,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/pattern-activity-panels-redux/package.json
+++ b/moonstone/pattern-activity-panels-redux/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -41,5 +41,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/pattern-activity-panels/package.json
+++ b/moonstone/pattern-activity-panels/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -38,5 +38,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/pattern-analytics-webostv/package.json
+++ b/moonstone/pattern-analytics-webostv/package.json
@@ -25,7 +25,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/analytics": "^1.0.1",
@@ -38,5 +38,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/pattern-dynamic-panel/package.json
+++ b/moonstone/pattern-dynamic-panel/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -39,5 +39,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/pattern-expandablelist-object/package.json
+++ b/moonstone/pattern-expandablelist-object/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -38,5 +38,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/pattern-layout/package.json
+++ b/moonstone/pattern-layout/package.json
@@ -24,7 +24,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -38,5 +38,8 @@
     "query-string": "^7.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/pattern-locale-switching/package.json
+++ b/moonstone/pattern-locale-switching/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -42,5 +42,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/pattern-routable-panels/package.json
+++ b/moonstone/pattern-routable-panels/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -41,5 +41,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/pattern-single-panel-redux/package.json
+++ b/moonstone/pattern-single-panel-redux/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -41,5 +41,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/pattern-single-panel/package.json
+++ b/moonstone/pattern-single-panel/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -38,5 +38,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/pattern-video-player/package.json
+++ b/moonstone/pattern-video-player/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -38,5 +38,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/pattern-virtualgridlist-api/package.json
+++ b/moonstone/pattern-virtualgridlist-api/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -41,5 +41,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/pattern-virtuallist-preserving-focus/package.json
+++ b/moonstone/pattern-virtuallist-preserving-focus/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -41,5 +41,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/tutorial-hello-enact/package.json
+++ b/moonstone/tutorial-hello-enact/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -38,5 +38,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/moonstone/tutorial-kitten-browser/package.json
+++ b/moonstone/tutorial-kitten-browser/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -39,5 +39,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/my-theme-app/package.json
+++ b/my-theme-app/package.json
@@ -25,7 +25,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact"
+    "extends": "enact-proxy"
   },
   "eslintIgnore": [
     "node_modules/*",
@@ -42,5 +42,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,10 +13,13 @@
   "private": true,
   "repository": "https://github.com/enactjs/samples",
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "readdirp": "^3.6.0",
     "shelljs": "^0.8.5"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/all-samples/package.json
+++ b/sandstone/all-samples/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -45,5 +45,8 @@
     "react-router-dom": "^6.8.0",
     "redux": "^4.2.1",
     "redux-thunk": "^2.4.2"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/custom-skin/package.json
+++ b/sandstone/custom-skin/package.json
@@ -22,7 +22,7 @@
 		"theme": "sandstone"
 	},
 	"eslintConfig": {
-		"extends": "enact/strict"
+		"extends": "enact-proxy/strict"
 	},
 	"eslintIgnore": [
 		"node_modules/*",
@@ -40,5 +40,8 @@
 		"prop-types": "^15.8.1",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0"
+	},
+	"devDependencies": {
+		"eslint-config-enact-proxy": "^1.0.5"
 	}
 }

--- a/sandstone/pattern-account-icon/package.json
+++ b/sandstone/pattern-account-icon/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -38,5 +38,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/pattern-analytics-webostv/package.json
+++ b/sandstone/pattern-analytics-webostv/package.json
@@ -25,7 +25,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/analytics": "^1.0.1",
@@ -38,5 +38,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/pattern-dynamic-panel/package.json
+++ b/sandstone/pattern-dynamic-panel/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -39,5 +39,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/pattern-layout/package.json
+++ b/sandstone/pattern-layout/package.json
@@ -24,7 +24,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -38,5 +38,8 @@
     "query-string": "^7.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/pattern-locale-switching/package.json
+++ b/sandstone/pattern-locale-switching/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -42,5 +42,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/pattern-ls2request-camera/package.json
+++ b/sandstone/pattern-ls2request-camera/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -42,5 +42,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/pattern-react18-new/package.json
+++ b/sandstone/pattern-react18-new/package.json
@@ -22,7 +22,7 @@
     "theme": "sandstone"
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "eslintIgnore": [
     "node_modules/*",
@@ -40,5 +40,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/pattern-routable-panels/package.json
+++ b/sandstone/pattern-routable-panels/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -41,5 +41,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/pattern-single-panel-redux/package.json
+++ b/sandstone/pattern-single-panel-redux/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -41,5 +41,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/pattern-single-panel/package.json
+++ b/sandstone/pattern-single-panel/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -38,5 +38,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/pattern-video-player/package.json
+++ b/sandstone/pattern-video-player/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -38,5 +38,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/pattern-virtualgridlist-api/package.json
+++ b/sandstone/pattern-virtualgridlist-api/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -41,5 +41,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/pattern-virtuallist-preserving-focus/package.json
+++ b/sandstone/pattern-virtuallist-preserving-focus/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -41,5 +41,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/tutorial-hello-enact/package.json
+++ b/sandstone/tutorial-hello-enact/package.json
@@ -24,7 +24,7 @@
     "theme": "sandstone"
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -36,5 +36,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/sandstone/tutorial-kitten-browser/package.json
+++ b/sandstone/tutorial-kitten-browser/package.json
@@ -24,7 +24,7 @@
     "theme": "sandstone"
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -37,5 +37,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/tutorial-typescript/package.json
+++ b/tutorial-typescript/package.json
@@ -22,7 +22,7 @@
 		"theme": "sandstone"
 	},
 	"eslintConfig": {
-		"extends": "enact"
+		"extends": "enact-proxy"
 	},
 	"eslintIgnore": [
 		"node_modules/*",
@@ -43,5 +43,8 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"typescript": "^4.9.5"
+	},
+	"devDependencies": {
+		"eslint-config-enact-proxy": "^1.0.5"
 	}
 }

--- a/ui/all-samples/package.json
+++ b/ui/all-samples/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -44,5 +44,8 @@
     "react-router-dom": "^6.8.0",
     "redux": "^4.2.1",
     "redux-thunk": "^2.4.2"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/ui/pattern-analytics/package.json
+++ b/ui/pattern-analytics/package.json
@@ -25,7 +25,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/analytics": "^1.0.1",
@@ -37,5 +37,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/ui/pattern-list-details-redux/package.json
+++ b/ui/pattern-list-details-redux/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -40,5 +40,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/ui/pattern-list-details/package.json
+++ b/ui/pattern-list-details/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -37,5 +37,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/ui/pattern-ls2request/package.json
+++ b/ui/pattern-ls2request/package.json
@@ -26,7 +26,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact/strict"
+    "extends": "enact-proxy/strict"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",
@@ -41,5 +41,8 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
At the moment, samples doesn't have eslint-config-enact-proxy installed which allows linting through the eslint command and enables the in-editor linting function in the IDE.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed samples to use eslint-config-enact-proxy by adding the commands to each sample package.json.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-5254

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com