### PR TITLE
WRP-9221: Update .travis.yml to change the CLI downloading method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: focal
 language: node_js
 node_js:
     - lts/*
-    - "18"
+    - node
 sudo: false
 install:
     - git clone --branch=develop --depth 1 https://github.com/enactjs/cli ../cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ node_js:
     - "18"
 sudo: false
 install:
-    - npm install -g enactjs/cli#develop
+    - git clone --branch=develop --depth 1 https://github.com/enactjs/cli ../cli
+    - pushd ../cli
+    - npm install
+    - npm link
+    - popd
     - npm install
 script:
     - echo -e "\x1b\x5b35;1m*** Starting eslint...\x1b\x5b0m"


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
1. There is a difference between 'npm install gitbranch' and 'git clone gitbranch' -> 'npm install'.
Need to use the git clone method to follow the already tested npm-shrinkwrap.json during travis build.
2. Need to test current node version.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
1. Update .travis.yml to download the cli source code with git clone and then run 'npm install' and 'npm link' in the cli directory.
2. Added current node version test again because node 19 support in canvas 2.10.2 library was provided.

### Links
[//]: # (Related issues, references)
WRP-9221

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)