### PR TITLE
WRP-12308: replace PalmSystem with webOSSystem

### DIFF
--- a/sandstone/pattern-ls2request-camera/src/components/CameraView.js
+++ b/sandstone/pattern-ls2request-camera/src/components/CameraView.js
@@ -18,7 +18,7 @@ const CameraView = () => {
 	let cameraOption;
 
 	useEffect(() => {
-		if (typeof window !== 'undefined' && typeof window.PalmSystem !== 'undefined') {
+		if (typeof window !== 'undefined' && typeof (window.webOSSystem ?? window.PalmSystem) !== 'undefined') {
 			dispatch(getCameraIds({}));
 		}
 	}, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -30,12 +30,12 @@ const CameraView = () => {
 	}, [cameraStatus]);
 
 	const checkSystem = () => {
-		if (typeof window === 'undefined' || typeof window.PalmSystem === 'undefined') {
+		if (typeof window === 'undefined' || typeof (window.webOSSystem ?? window.PalmSystem) === 'undefined') {
 			return <div>This test will only function correctly on webOS systems!</div>;
 		}
 	};
 
-	if (typeof window !== 'undefined' && typeof window.PalmSystem === 'undefined') {
+	if (typeof window !== 'undefined' && typeof (window.webOSSystem ?? window.PalmSystem) === 'undefined') {
 		return <div>This test will only function correctly on webOS systems!</div>;
 	}
 

--- a/ui/pattern-ls2request/src/App/App.js
+++ b/ui/pattern-ls2request/src/App/App.js
@@ -12,7 +12,7 @@ const App = () => {
 	const dispatch = useDispatch();
 
 	useEffect(() => {
-		if (typeof window !== 'undefined' && typeof window.PalmSystem !== 'undefined') {
+		if (typeof window !== 'undefined' && typeof (window.webOSSystem ?? window.PalmSystem) !== 'undefined') {
 			dispatch(getSystemSettings({
 				category: 'picture',
 				key: 'brightness'
@@ -58,12 +58,12 @@ const App = () => {
 	}), [eyeComfortMode]);
 
 	const checkSystem = () => {
-		if (typeof window === 'undefined' || typeof window.PalmSystem === 'undefined') {
+		if (typeof window === 'undefined' || typeof (window.webOSSystem ?? window.PalmSystem) === 'undefined') {
 			return <div>This test will only function correctly on webOS systems!</div>;
 		}
 	};
 
-	if (typeof window === 'undefined' || typeof window.PalmSystem === 'undefined') {
+	if (typeof window === 'undefined' || typeof (window.webOSSystem ?? window.PalmSystem) === 'undefined') {
 		return <div className={css.main}>This test will only function correctly on webOS systems!</div>;
 	}
 


### PR DESCRIPTION
In 2018, PalmSystem was renamed to webOSSystem. (Note: in a browser environment, the same object has old and new names.) And PalmSystem is only used for backward compatibility purposes.

Replace PalmSystem with webOSSystem while still using PalmSystem as a fallback.

Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>