### PR TITLE
WRQ-4081: Fix the enact-sample-zip error

### DIFF
--- a/sandstone/all-samples/package.json
+++ b/sandstone/all-samples/package.json
@@ -36,6 +36,7 @@
     "@enact/ui": "^4.7.2",
     "@enact/webos": "^4.7.2",
     "@reduxjs/toolkit": "^1.9.5",
+    "classnames": "^2.3.2",
     "ilib": "^14.18.0",
     "prop-types": "^15.8.1",
     "query-string": "^8.1.0",


### PR DESCRIPTION
Add the 'classnames' dependency to fix the following error.
`Module not found: Error: Can't resolve 'classnames' in '/home/jenkins/workspace/enact-samples-zip/enact-samples/pattern-react18-new/src/App'`