### PR TITLE
WRQ-22143: Fix TutorialKittenBrowser sample: Panel does not change

### DIFF
--- a/sandstone/tutorial-kitten-browser/src/App/App.js
+++ b/sandstone/tutorial-kitten-browser/src/App/App.js
@@ -16,7 +16,7 @@ const kittens = [
 	'Kitty'
 ];
 
-const AppBase = kind({
+const Sample = kind({
 	name: 'App',
 
 	propTypes: {
@@ -60,11 +60,13 @@ const AppBase = kind({
 	}
 });
 
-const App = Changeable({prop: 'panelIndex', change: 'onPanelIndexChange'},
+const AppBase = Changeable({prop: 'panelIndex', change: 'onPanelIndexChange'},
 	Changeable({prop: 'kittenIndex', change: 'onKittenIndexChange'},
-		ThemeDecorator(AppBase)
+		Sample
 	)
 );
+
+const App = ThemeDecorator(AppBase);
 
 export default App;
 export {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Clicking kitten image does not change panel to 'detail' in TutorialKittenBrowser sample.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Commit https://github.com/enactjs/samples/commit/616a50923761550af7d22298e60da55b25f300e1 caused this issue.
Because `AppBase` is exported from `tutorial-kitten-browser` to `all-samples` without `Changeable` function, there was not handler function to change panel. 
I reverted the code that caused the issue.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim ([jiye.kim@lge.com](mailto:jiye.kim@lge.com))