### PR TITLE
WRR-1005: Fixed samples to work with Eslint 9 flat config

### DIFF
--- a/sandstone/feature-custom-skin-generator/src/components/OutputField/OutputField.js
+++ b/sandstone/feature-custom-skin-generator/src/components/OutputField/OutputField.js
@@ -168,7 +168,6 @@ const OutputField = kind({
 	render: ({fullCSS, generateFile, handleClose, handleFocus, handleFullCSS, handleOpen, onToggleOpen, popupOpen, setDefaultState, text}) => {
 		// Function that copies the content of the custom-skin css file into clipboard
 		function copyToClipboard () {
-			/* global navigator */
 			return navigator.clipboard?.writeText(text);
 		}
 

--- a/tutorial-typescript/src/components/Counter/Counter.tsx
+++ b/tutorial-typescript/src/components/Counter/Counter.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable enact/prop-types */
+
 import {adaptEvent, forward, handle} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import Button from '@enact/sandstone/Button';

--- a/tutorial-typescript/src/components/Counter/Counter.tsx
+++ b/tutorial-typescript/src/components/Counter/Counter.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable enact/prop-types */
-
 import {adaptEvent, forward, handle} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import Button from '@enact/sandstone/Button';


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed samples to work with Eslint 9 flat config
```shell
Failed to compile.

[eslint] 
src/components/OutputField/OutputField.js
  Line 171:14:  'navigator' is already defined as a built-in global variable  no-redeclare
// Already defined in `shared-node-browser` config, installed in `eslint-config-enact`
``` 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix the lint error

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-1005

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)