### PR TITLE
WRR-22104: Remove .eslintignore files in samples repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+### Checklist
+
+* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
+* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
+* [ ] At least one test case is included for this feature or bug fix
+* [ ] Documentation was added or is not needed
+* [ ] This is an API breaking change
+
+### Issue Resolved / Feature Added
+[//]: # (Describe the issue resolved or feature added by this pull request)
+
+
+### Resolution
+[//]: # (Does the code work as intended?)
+[//]: # (What is the impact of this change and *why* was it made?)
+
+
+### Additional Considerations
+[//]: # (How should the change be tested?)
+[//]: # (Are there any outstanding questions?)
+[//]: # (Were any side-effects caused by the change?)
+
+
+### Links
+[//]: # (Related issues, references)
+
+
+### Comments

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ All samples may be accessed from a single app in the `enact-all-samples` directo
 
 Unless otherwise specified, all content, including all source code files and documentation files in this repository are:
 
-Copyright (c) 2012-2026 LG Electronics
+Copyright (c) 2012-2025 LG Electronics
 
 Unless otherwise specified or set forth in the NOTICE file, all content, including all source code files and documentation files in this repository are: Licensed under the Apache License, Version 2.0 (the "License"); you may not use this content except in compliance with the License. You may obtain a copy of the License at
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ All samples may be accessed from a single app in the `enact-all-samples` directo
 
 Unless otherwise specified, all content, including all source code files and documentation files in this repository are:
 
-Copyright (c) 2012-2022 LG Electronics
+Copyright (c) 2012-2026 LG Electronics
 
 Unless otherwise specified or set forth in the NOTICE file, all content, including all source code files and documentation files in this repository are: Licensed under the Apache License, Version 2.0 (the "License"); you may not use this content except in compliance with the License. You may obtain a copy of the License at
 

--- a/agate/all-samples/.eslintignore
+++ b/agate/all-samples/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/agate/all-samples/eslint.config.js
+++ b/agate/all-samples/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/agate/all-samples/eslint.config.js
+++ b/agate/all-samples/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/agate/all-samples/eslint.config.js
+++ b/agate/all-samples/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/agate/pattern-dynamic-panel/.eslintignore
+++ b/agate/pattern-dynamic-panel/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/agate/pattern-dynamic-panel/eslint.config.js
+++ b/agate/pattern-dynamic-panel/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/agate/pattern-dynamic-panel/eslint.config.js
+++ b/agate/pattern-dynamic-panel/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/agate/pattern-dynamic-panel/eslint.config.js
+++ b/agate/pattern-dynamic-panel/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/agate/pattern-layout/.eslintignore
+++ b/agate/pattern-layout/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/agate/pattern-layout/eslint.config.js
+++ b/agate/pattern-layout/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/agate/pattern-layout/eslint.config.js
+++ b/agate/pattern-layout/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/agate/pattern-layout/eslint.config.js
+++ b/agate/pattern-layout/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/agate/pattern-locale-switching/.eslintignore
+++ b/agate/pattern-locale-switching/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/agate/pattern-locale-switching/eslint.config.js
+++ b/agate/pattern-locale-switching/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/agate/pattern-locale-switching/eslint.config.js
+++ b/agate/pattern-locale-switching/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/agate/pattern-locale-switching/eslint.config.js
+++ b/agate/pattern-locale-switching/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/agate/pattern-single-panel-redux/.eslintignore
+++ b/agate/pattern-single-panel-redux/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/agate/pattern-single-panel-redux/eslint.config.js
+++ b/agate/pattern-single-panel-redux/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/agate/pattern-single-panel-redux/eslint.config.js
+++ b/agate/pattern-single-panel-redux/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/agate/pattern-single-panel-redux/eslint.config.js
+++ b/agate/pattern-single-panel-redux/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/agate/pattern-single-panel/.eslintignore
+++ b/agate/pattern-single-panel/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/agate/pattern-single-panel/eslint.config.js
+++ b/agate/pattern-single-panel/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/agate/pattern-single-panel/eslint.config.js
+++ b/agate/pattern-single-panel/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/agate/pattern-single-panel/eslint.config.js
+++ b/agate/pattern-single-panel/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/agate/pattern-virtualgridlist-api/.eslintignore
+++ b/agate/pattern-virtualgridlist-api/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/agate/pattern-virtualgridlist-api/eslint.config.js
+++ b/agate/pattern-virtualgridlist-api/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/agate/pattern-virtualgridlist-api/eslint.config.js
+++ b/agate/pattern-virtualgridlist-api/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/agate/pattern-virtualgridlist-api/eslint.config.js
+++ b/agate/pattern-virtualgridlist-api/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/agate/pattern-virtuallist-preserving-focus/.eslintignore
+++ b/agate/pattern-virtuallist-preserving-focus/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/agate/pattern-virtuallist-preserving-focus/eslint.config.js
+++ b/agate/pattern-virtuallist-preserving-focus/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/agate/pattern-virtuallist-preserving-focus/eslint.config.js
+++ b/agate/pattern-virtuallist-preserving-focus/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/agate/pattern-virtuallist-preserving-focus/eslint.config.js
+++ b/agate/pattern-virtuallist-preserving-focus/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/all-samples/.eslintignore
+++ b/moonstone/all-samples/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/all-samples/eslint.config.js
+++ b/moonstone/all-samples/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/all-samples/eslint.config.js
+++ b/moonstone/all-samples/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/all-samples/eslint.config.js
+++ b/moonstone/all-samples/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/pattern-activity-panels-deep-linking/.eslintignore
+++ b/moonstone/pattern-activity-panels-deep-linking/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/pattern-activity-panels-deep-linking/eslint.config.js
+++ b/moonstone/pattern-activity-panels-deep-linking/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/pattern-activity-panels-deep-linking/eslint.config.js
+++ b/moonstone/pattern-activity-panels-deep-linking/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/pattern-activity-panels-deep-linking/eslint.config.js
+++ b/moonstone/pattern-activity-panels-deep-linking/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/pattern-activity-panels-redux/.eslintignore
+++ b/moonstone/pattern-activity-panels-redux/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/pattern-activity-panels-redux/eslint.config.js
+++ b/moonstone/pattern-activity-panels-redux/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/pattern-activity-panels-redux/eslint.config.js
+++ b/moonstone/pattern-activity-panels-redux/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/pattern-activity-panels-redux/eslint.config.js
+++ b/moonstone/pattern-activity-panels-redux/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/pattern-activity-panels/.eslintignore
+++ b/moonstone/pattern-activity-panels/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/pattern-activity-panels/eslint.config.js
+++ b/moonstone/pattern-activity-panels/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/pattern-activity-panels/eslint.config.js
+++ b/moonstone/pattern-activity-panels/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/pattern-activity-panels/eslint.config.js
+++ b/moonstone/pattern-activity-panels/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/pattern-analytics-webostv/.eslintignore
+++ b/moonstone/pattern-analytics-webostv/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/pattern-analytics-webostv/eslint.config.js
+++ b/moonstone/pattern-analytics-webostv/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/pattern-analytics-webostv/eslint.config.js
+++ b/moonstone/pattern-analytics-webostv/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/pattern-analytics-webostv/eslint.config.js
+++ b/moonstone/pattern-analytics-webostv/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/pattern-dynamic-panel/.eslintignore
+++ b/moonstone/pattern-dynamic-panel/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/pattern-dynamic-panel/eslint.config.js
+++ b/moonstone/pattern-dynamic-panel/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/pattern-dynamic-panel/eslint.config.js
+++ b/moonstone/pattern-dynamic-panel/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/pattern-dynamic-panel/eslint.config.js
+++ b/moonstone/pattern-dynamic-panel/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/pattern-expandablelist-object/.eslintignore
+++ b/moonstone/pattern-expandablelist-object/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/pattern-expandablelist-object/eslint.config.js
+++ b/moonstone/pattern-expandablelist-object/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/pattern-expandablelist-object/eslint.config.js
+++ b/moonstone/pattern-expandablelist-object/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/pattern-expandablelist-object/eslint.config.js
+++ b/moonstone/pattern-expandablelist-object/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/pattern-layout/.eslintignore
+++ b/moonstone/pattern-layout/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/pattern-layout/eslint.config.js
+++ b/moonstone/pattern-layout/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/pattern-layout/eslint.config.js
+++ b/moonstone/pattern-layout/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/pattern-layout/eslint.config.js
+++ b/moonstone/pattern-layout/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/pattern-locale-switching/.eslintignore
+++ b/moonstone/pattern-locale-switching/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/pattern-locale-switching/eslint.config.js
+++ b/moonstone/pattern-locale-switching/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/pattern-locale-switching/eslint.config.js
+++ b/moonstone/pattern-locale-switching/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/pattern-locale-switching/eslint.config.js
+++ b/moonstone/pattern-locale-switching/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/pattern-routable-panels/.eslintignore
+++ b/moonstone/pattern-routable-panels/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/pattern-routable-panels/eslint.config.js
+++ b/moonstone/pattern-routable-panels/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/pattern-routable-panels/eslint.config.js
+++ b/moonstone/pattern-routable-panels/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/pattern-routable-panels/eslint.config.js
+++ b/moonstone/pattern-routable-panels/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/pattern-single-panel-redux/.eslintignore
+++ b/moonstone/pattern-single-panel-redux/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/pattern-single-panel-redux/eslint.config.js
+++ b/moonstone/pattern-single-panel-redux/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/pattern-single-panel-redux/eslint.config.js
+++ b/moonstone/pattern-single-panel-redux/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/pattern-single-panel-redux/eslint.config.js
+++ b/moonstone/pattern-single-panel-redux/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/pattern-single-panel/.eslintignore
+++ b/moonstone/pattern-single-panel/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/pattern-single-panel/eslint.config.js
+++ b/moonstone/pattern-single-panel/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/pattern-single-panel/eslint.config.js
+++ b/moonstone/pattern-single-panel/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/pattern-single-panel/eslint.config.js
+++ b/moonstone/pattern-single-panel/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/pattern-video-player/.eslintignore
+++ b/moonstone/pattern-video-player/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/pattern-video-player/eslint.config.js
+++ b/moonstone/pattern-video-player/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/pattern-video-player/eslint.config.js
+++ b/moonstone/pattern-video-player/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/pattern-video-player/eslint.config.js
+++ b/moonstone/pattern-video-player/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/pattern-virtualgridlist-api/.eslintignore
+++ b/moonstone/pattern-virtualgridlist-api/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/pattern-virtualgridlist-api/eslint.config.js
+++ b/moonstone/pattern-virtualgridlist-api/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/pattern-virtualgridlist-api/eslint.config.js
+++ b/moonstone/pattern-virtualgridlist-api/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/pattern-virtualgridlist-api/eslint.config.js
+++ b/moonstone/pattern-virtualgridlist-api/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/pattern-virtuallist-preserving-focus/.eslintignore
+++ b/moonstone/pattern-virtuallist-preserving-focus/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/pattern-virtuallist-preserving-focus/eslint.config.js
+++ b/moonstone/pattern-virtuallist-preserving-focus/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/pattern-virtuallist-preserving-focus/eslint.config.js
+++ b/moonstone/pattern-virtuallist-preserving-focus/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/pattern-virtuallist-preserving-focus/eslint.config.js
+++ b/moonstone/pattern-virtuallist-preserving-focus/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/tutorial-hello-enact/.eslintignore
+++ b/moonstone/tutorial-hello-enact/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/tutorial-hello-enact/eslint.config.js
+++ b/moonstone/tutorial-hello-enact/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/tutorial-hello-enact/eslint.config.js
+++ b/moonstone/tutorial-hello-enact/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/tutorial-hello-enact/eslint.config.js
+++ b/moonstone/tutorial-hello-enact/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/moonstone/tutorial-kitten-browser/.eslintignore
+++ b/moonstone/tutorial-kitten-browser/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/moonstone/tutorial-kitten-browser/eslint.config.js
+++ b/moonstone/tutorial-kitten-browser/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/moonstone/tutorial-kitten-browser/eslint.config.js
+++ b/moonstone/tutorial-kitten-browser/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/moonstone/tutorial-kitten-browser/eslint.config.js
+++ b/moonstone/tutorial-kitten-browser/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/all-samples/.eslintignore
+++ b/sandstone/all-samples/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/all-samples/eslint.config.js
+++ b/sandstone/all-samples/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/all-samples/eslint.config.js
+++ b/sandstone/all-samples/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/all-samples/eslint.config.js
+++ b/sandstone/all-samples/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/pattern-account-icon/.eslintignore
+++ b/sandstone/pattern-account-icon/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/pattern-account-icon/eslint.config.js
+++ b/sandstone/pattern-account-icon/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/pattern-account-icon/eslint.config.js
+++ b/sandstone/pattern-account-icon/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/pattern-account-icon/eslint.config.js
+++ b/sandstone/pattern-account-icon/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/pattern-analytics-webostv/.eslintignore
+++ b/sandstone/pattern-analytics-webostv/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/pattern-analytics-webostv/eslint.config.js
+++ b/sandstone/pattern-analytics-webostv/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/pattern-analytics-webostv/eslint.config.js
+++ b/sandstone/pattern-analytics-webostv/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/pattern-analytics-webostv/eslint.config.js
+++ b/sandstone/pattern-analytics-webostv/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/pattern-dynamic-panel/.eslintignore
+++ b/sandstone/pattern-dynamic-panel/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/pattern-dynamic-panel/eslint.config.js
+++ b/sandstone/pattern-dynamic-panel/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/pattern-dynamic-panel/eslint.config.js
+++ b/sandstone/pattern-dynamic-panel/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/pattern-dynamic-panel/eslint.config.js
+++ b/sandstone/pattern-dynamic-panel/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/pattern-layout/.eslintignore
+++ b/sandstone/pattern-layout/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/pattern-layout/eslint.config.js
+++ b/sandstone/pattern-layout/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/pattern-layout/eslint.config.js
+++ b/sandstone/pattern-layout/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/pattern-layout/eslint.config.js
+++ b/sandstone/pattern-layout/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/pattern-locale-switching/.eslintignore
+++ b/sandstone/pattern-locale-switching/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/pattern-locale-switching/eslint.config.js
+++ b/sandstone/pattern-locale-switching/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/pattern-locale-switching/eslint.config.js
+++ b/sandstone/pattern-locale-switching/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/pattern-locale-switching/eslint.config.js
+++ b/sandstone/pattern-locale-switching/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/pattern-ls2request-camera/.eslintignore
+++ b/sandstone/pattern-ls2request-camera/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/pattern-ls2request-camera/eslint.config.js
+++ b/sandstone/pattern-ls2request-camera/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/pattern-ls2request-camera/eslint.config.js
+++ b/sandstone/pattern-ls2request-camera/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/pattern-ls2request-camera/eslint.config.js
+++ b/sandstone/pattern-ls2request-camera/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/pattern-routable-panels/.eslintignore
+++ b/sandstone/pattern-routable-panels/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/pattern-routable-panels/eslint.config.js
+++ b/sandstone/pattern-routable-panels/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/pattern-routable-panels/eslint.config.js
+++ b/sandstone/pattern-routable-panels/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/pattern-routable-panels/eslint.config.js
+++ b/sandstone/pattern-routable-panels/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/pattern-single-panel-redux/.eslintignore
+++ b/sandstone/pattern-single-panel-redux/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/pattern-single-panel-redux/eslint.config.js
+++ b/sandstone/pattern-single-panel-redux/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/pattern-single-panel-redux/eslint.config.js
+++ b/sandstone/pattern-single-panel-redux/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/pattern-single-panel-redux/eslint.config.js
+++ b/sandstone/pattern-single-panel-redux/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/pattern-single-panel/.eslintignore
+++ b/sandstone/pattern-single-panel/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/pattern-single-panel/eslint.config.js
+++ b/sandstone/pattern-single-panel/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/pattern-single-panel/eslint.config.js
+++ b/sandstone/pattern-single-panel/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/pattern-single-panel/eslint.config.js
+++ b/sandstone/pattern-single-panel/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/pattern-video-player-custom/.eslintignore
+++ b/sandstone/pattern-video-player-custom/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/pattern-video-player-custom/eslint.config.js
+++ b/sandstone/pattern-video-player-custom/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/pattern-video-player-custom/eslint.config.js
+++ b/sandstone/pattern-video-player-custom/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/pattern-video-player-custom/eslint.config.js
+++ b/sandstone/pattern-video-player-custom/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/pattern-video-player/.eslintignore
+++ b/sandstone/pattern-video-player/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/pattern-video-player/eslint.config.js
+++ b/sandstone/pattern-video-player/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/pattern-video-player/eslint.config.js
+++ b/sandstone/pattern-video-player/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/pattern-video-player/eslint.config.js
+++ b/sandstone/pattern-video-player/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/pattern-virtualgridlist-api/.eslintignore
+++ b/sandstone/pattern-virtualgridlist-api/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/pattern-virtualgridlist-api/eslint.config.js
+++ b/sandstone/pattern-virtualgridlist-api/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/pattern-virtualgridlist-api/eslint.config.js
+++ b/sandstone/pattern-virtualgridlist-api/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/pattern-virtualgridlist-api/eslint.config.js
+++ b/sandstone/pattern-virtualgridlist-api/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/pattern-virtuallist-preserving-focus/.eslintignore
+++ b/sandstone/pattern-virtuallist-preserving-focus/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/pattern-virtuallist-preserving-focus/eslint.config.js
+++ b/sandstone/pattern-virtuallist-preserving-focus/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/pattern-virtuallist-preserving-focus/eslint.config.js
+++ b/sandstone/pattern-virtuallist-preserving-focus/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/pattern-virtuallist-preserving-focus/eslint.config.js
+++ b/sandstone/pattern-virtuallist-preserving-focus/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/tutorial-hello-enact/.eslintignore
+++ b/sandstone/tutorial-hello-enact/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/tutorial-hello-enact/eslint.config.js
+++ b/sandstone/tutorial-hello-enact/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/tutorial-hello-enact/eslint.config.js
+++ b/sandstone/tutorial-hello-enact/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/tutorial-hello-enact/eslint.config.js
+++ b/sandstone/tutorial-hello-enact/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/sandstone/tutorial-kitten-browser/.eslintignore
+++ b/sandstone/tutorial-kitten-browser/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/sandstone/tutorial-kitten-browser/eslint.config.js
+++ b/sandstone/tutorial-kitten-browser/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/sandstone/tutorial-kitten-browser/eslint.config.js
+++ b/sandstone/tutorial-kitten-browser/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/sandstone/tutorial-kitten-browser/eslint.config.js
+++ b/sandstone/tutorial-kitten-browser/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/ui/all-samples/.eslintignore
+++ b/ui/all-samples/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/ui/all-samples/eslint.config.js
+++ b/ui/all-samples/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/ui/all-samples/eslint.config.js
+++ b/ui/all-samples/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/ui/all-samples/eslint.config.js
+++ b/ui/all-samples/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/ui/pattern-analytics/.eslintignore
+++ b/ui/pattern-analytics/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/ui/pattern-analytics/eslint.config.js
+++ b/ui/pattern-analytics/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/ui/pattern-analytics/eslint.config.js
+++ b/ui/pattern-analytics/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/ui/pattern-analytics/eslint.config.js
+++ b/ui/pattern-analytics/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/ui/pattern-list-details-redux/.eslintignore
+++ b/ui/pattern-list-details-redux/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/ui/pattern-list-details-redux/eslint.config.js
+++ b/ui/pattern-list-details-redux/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/ui/pattern-list-details-redux/eslint.config.js
+++ b/ui/pattern-list-details-redux/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/ui/pattern-list-details-redux/eslint.config.js
+++ b/ui/pattern-list-details-redux/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/ui/pattern-list-details/.eslintignore
+++ b/ui/pattern-list-details/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/ui/pattern-list-details/eslint.config.js
+++ b/ui/pattern-list-details/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/ui/pattern-list-details/eslint.config.js
+++ b/ui/pattern-list-details/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/ui/pattern-list-details/eslint.config.js
+++ b/ui/pattern-list-details/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);

--- a/ui/pattern-ls2request/.eslintignore
+++ b/ui/pattern-ls2request/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/*
-build/*
-dist/*

--- a/ui/pattern-ls2request/eslint.config.js
+++ b/ui/pattern-ls2request/eslint.config.js
@@ -1,13 +1,10 @@
-import {defineConfig, globalIgnores} from "eslint/config";
-import {includeIgnoreFile} from "@eslint/compat";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
+module.exports = [
+	{
+		ignores: [
+			'node_modules/*',
+			'build/*',
+			'dist/*'
+		]
+	}
+];
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
-export default defineConfig([
-	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-	includeIgnoreFile(gitignorePath)
-]);

--- a/ui/pattern-ls2request/eslint.config.js
+++ b/ui/pattern-ls2request/eslint.config.js
@@ -1,13 +1,13 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import { includeIgnoreFile } from "@eslint/compat";
+import {defineConfig, globalIgnores} from "eslint/config";
+import {includeIgnoreFile} from "@eslint/compat";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {fileURLToPath} from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default defineConfig([
-    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
-    includeIgnoreFile(gitignorePath),
+	globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+	includeIgnoreFile(gitignorePath)
 ]);

--- a/ui/pattern-ls2request/eslint.config.js
+++ b/ui/pattern-ls2request/eslint.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const gitignorePath = path.resolve(__dirname, ".gitignore");
+
+export default defineConfig([
+    globalIgnores(["node_modules/*", "build/*", "dist/*"]),
+    includeIgnoreFile(gitignorePath),
+]);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Starting with Enact CLI 7.0.0-alpha.5, linting is enabled with eslint 9 when building apps.
Because of this, the eslintIgnore configs that were previously working will no longer work.
We need to analyze how to change these configs.
https://app.travis-ci.com/github/enactjs/samples/jobs/631451870

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Remove `.eslintignore` files in samples repo
- Migrate `.eslintignore` to `eslint.config.js`

### Additional Considerations
- Add `.github/PULL_REQUEST_TEMPLATE.md`
- Update copyright years in `README.md`

### Links
[//]: # (Related issues, references)
WRQ-22104

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)