### PR TITLE
WRR-23385: Remove unused eslint-disable directive 'enact/prop-types'

### DIFF
--- a/agate/pattern-layout/src/views/FavoritesList.js
+++ b/agate/pattern-layout/src/views/FavoritesList.js
@@ -15,7 +15,7 @@ const SpottableContainer = SpotlightContainerDecorator({enterTo: 'last-focused'}
 
 const items = Array(80).fill().map((_, i) => 'Item ' + (i + 1));
 
-// eslint-disable-next-line enact/display-name, enact/prop-types
+// eslint-disable-next-line enact/display-name
 const renderItem = () => ({index, ...rest}) => (
 	<Item {...rest}>
 		{items[index]}

--- a/agate/pattern-layout/src/views/MainPanel.js
+++ b/agate/pattern-layout/src/views/MainPanel.js
@@ -31,7 +31,7 @@ const GridItem = kind({
 	}
 });
 
-// eslint-disable-next-line enact/display-name, enact/prop-types
+// eslint-disable-next-line enact/display-name
 const renderItem = ({items, onChangePanel}) => ({index, ...rest}) => {
 	if (items && items[index]) {
 		return (

--- a/moonstone/pattern-layout/src/views/FavoritesList.js
+++ b/moonstone/pattern-layout/src/views/FavoritesList.js
@@ -14,7 +14,7 @@ const SpottableContainer = SpotlightContainerDecorator({enterTo: 'last-focused'}
 
 const items = Array(80).fill().map((_, i) => 'Item ' + (i + 1));
 
-// eslint-disable-next-line enact/display-name, enact/prop-types
+// eslint-disable-next-line enact/display-name
 const renderItem = () => ({index, ...rest}) => (
 	<Item {...rest}>
 		{items[index]}

--- a/moonstone/pattern-layout/src/views/MainPanel.js
+++ b/moonstone/pattern-layout/src/views/MainPanel.js
@@ -30,7 +30,7 @@ const GridItem = kind({
 	}
 });
 
-// eslint-disable-next-line enact/display-name, enact/prop-types
+// eslint-disable-next-line enact/display-name
 const renderItem = ({items, onChangePanel}) => ({index, ...rest}) => {
 	if (items && items[index]) {
 		return (

--- a/sandstone/pattern-layout/src/views/FavoritesList.js
+++ b/sandstone/pattern-layout/src/views/FavoritesList.js
@@ -14,7 +14,7 @@ const SpottableContainer = SpotlightContainerDecorator({enterTo: 'last-focused'}
 
 const items = Array(80).fill().map((_, i) => 'Item ' + (i + 1));
 
-// eslint-disable-next-line enact/display-name, enact/prop-types
+// eslint-disable-next-line enact/display-name
 const renderItem = () => ({index, ...rest}) => (
 	<Item {...rest}>
 		{items[index]}

--- a/sandstone/pattern-layout/src/views/MainPanel.js
+++ b/sandstone/pattern-layout/src/views/MainPanel.js
@@ -31,7 +31,7 @@ const GridItem = kind({
 	}
 });
 
-// eslint-disable-next-line enact/display-name, enact/prop-types
+// eslint-disable-next-line enact/display-name
 const renderItem = ({items, onChangePanel}) => ({index, ...rest}) => {
 	if (items && items[index]) {
 		return (


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
https://ko.react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-deprecated-react-apis
PropTypes were deprecated in April 2017 (v15.5.0).
However, the enact/prop-types rule still exists, so removing PropType causes a linting error.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove unused eslint-disable directive 'enact/prop-types'

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-23385

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)