### PR TITLE
NXT-7085: Updates node modules' major version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "dependencies": {
         "readdirp": "^5.0.0",
         "shelljs": "^0.10.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "shelljs": "^0.10.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.0.0 || >=24.0.0"
+        "node": ">= 20.19.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.7.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "readdirp": "^4.1.2",
+        "readdirp": "^5.0.0",
         "shelljs": "^0.10.0"
       }
     },
@@ -321,12 +321,12 @@
       "license": "MIT"
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "repository": "https://github.com/enactjs/samples",
   "dependencies": {
-    "readdirp": "^4.1.2",
+    "readdirp": "^5.0.0",
     "shelljs": "^0.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "repository": "https://github.com/enactjs/samples",
   "engines": {
-    "node": "^20.19.0 || ^22.0.0 || >=24.0.0"
+    "node": ">= 20.19.0"
   },
   "dependencies": {
     "readdirp": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "license": "Apache-2.0",
   "private": true,
   "repository": "https://github.com/enactjs/samples",
+  "engines": {
+    "node": "^20.19.0 || ^22.0.0 || >=24.0.0"
+  },
   "dependencies": {
     "readdirp": "^5.0.0",
     "shelljs": "^0.10.0"


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Alexandru Morariu alexandru.morariu@lgepartner.com

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Updates node modules' major version
readdirp 4.1.2 -> 5.0.0

- Make the package ESM-only. Reduces on-disk package size. (does not affect Enact)
- Increase minimum node.js version to v20.19. The versions starting from it support loading esm files from cjs (does not affect Enact)
https://github.com/paulmillr/readdirp/releases


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-7085

### Comments